### PR TITLE
Buildfix for using newlib's stdio

### DIFF
--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -24,6 +24,7 @@
 #include <stddef.h>
 #include <newlib.h>
 #include <sys/config.h>
+#include <sys/lock.h>
 #include <machine/_types.h>
 
 #ifndef __machine_blkcnt_t_defined
@@ -168,6 +169,10 @@ typedef struct
     unsigned char __wchb[4];
   } __value;		/* Value so far.  */
 } _mbstate_t;
+#endif
+
+#ifndef __machine_flock_t_defined
+typedef _LOCK_RECURSIVE_T _flock_t;
 #endif
 
 #ifndef __machine_iconv_t_defined

--- a/newlib/libc/include/sys/_types.h
+++ b/newlib/libc/include/sys/_types.h
@@ -24,7 +24,6 @@
 #include <stddef.h>
 #include <newlib.h>
 #include <sys/config.h>
-#include <sys/lock.h>
 #include <machine/_types.h>
 
 #ifndef __machine_blkcnt_t_defined
@@ -169,10 +168,6 @@ typedef struct
     unsigned char __wchb[4];
   } __value;		/* Value so far.  */
 } _mbstate_t;
-#endif
-
-#ifndef __machine_flock_t_defined
-typedef _LOCK_RECURSIVE_T _flock_t;
 #endif
 
 #ifndef __machine_iconv_t_defined

--- a/newlib/libc/include/sys/reent.h
+++ b/newlib/libc/include/sys/reent.h
@@ -17,6 +17,10 @@ extern "C" {
 
 #define _NULL 0
 
+#ifndef __machine_flock_t_defined
+#include <sys/lock.h>
+typedef _LOCK_RECURSIVE_T _flock_t;
+#endif
 struct _reent;
 
 /*

--- a/newlib/libc/stdio/meson.build
+++ b/newlib/libc/stdio/meson.build
@@ -58,6 +58,7 @@ general_srcs_stdio = [
   'freopen.c',
   'fscanf.c',
   'fseek.c',
+  'fseeko.c',
   'fsetpos.c',
   'ftell.c',
   'fvwrite.c',


### PR DESCRIPTION
Heya!
I recently found out about picolibc, and dang, it's really nice to have a version of newlib that has a more usable build system - I've lost more time than I'd like to admit trying to add source files to newlib upstream!
In any case, I'm trying this in a use case where file I/O is needed, therefore newlib's usual stdio. While I haven't tried it in practice yet, there was a typedef needed and an extra source file for it to compile - which is what you'll find in this patch.
Thanks for the awesome work! I've got a few more PRs incoming, hopefully they're useful.
-Ash