### PR TITLE
Buildfix for hardware floating-point machines

### DIFF
--- a/newlib/libm/mathfp/meson.build
+++ b/newlib/libm/mathfp/meson.build
@@ -137,6 +137,6 @@ foreach target : targets
 		static_library('mathfp' + target,
 			srcs_mathfp,
 			pic: false,
-			include_directories: inc,
+			include_directories: [ inc, include_directories('../common') ],
 			c_args: value[1]))
 endforeach


### PR DESCRIPTION
Hi again!
This one's a really simple buildfix. `math` has `libm/common` on the include path, while `mathfp` doesn't! This patch fixes that and lets mathfp compile.
Thanks,
-Ash 