### PR TITLE
Add build files for PowerPC platforms

### DIFF
--- a/newlib/libc/machine/powerpc/meson.build
+++ b/newlib/libc/machine/powerpc/meson.build
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright © 2019 Ash Logan, Keith Packard
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/newlib/libc/machine/powerpc/meson.build
+++ b/newlib/libc/machine/powerpc/meson.build
@@ -1,0 +1,68 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2019 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+srcs_machine = [
+  'atosfix16.c',
+  'atosfix32.c',
+  'atosfix64.c',
+  'atoufix16.c',
+  'atoufix32.c',
+  'atoufix64.c',
+  'setjmp.S',
+  'strtosfix16.c',
+  'strtosfix32.c',
+  'strtosfix64.c',
+  'strtoufix16.c',
+  'strtoufix32.c',
+  'strtoufix64.c',
+  'ufix64toa.c',
+#  These don't work with picolibc's stdio/malloc/locking
+#  'vec_calloc.c',
+#  'vec_free.c',
+#  'vec_malloc.c',
+#  'vec_mallocr.c',
+#  'vec_realloc.c',
+#  'vfprintf.c',
+#  'vfscanf.c',
+]
+
+foreach target : targets
+	value = get_variable('target_' + target)
+	set_variable('lib_machine' + target,
+		static_library('machine' + target,
+			srcs_machine,
+			pic: false,
+			include_directories: inc,
+			c_args: value[1] + ['-fno-builtin']))
+endforeach


### PR DESCRIPTION
Heya!
This adds a meson buildscript for the PowerPC machine folder. I had to leave off the vec_ files since they directly use reentrant syscalls, __malloc_lock, and other things like that. Those files are SIMD extensions in any case, and can always be patched and enabled later. Otherwise, cross-compiling to PowerPC seems to work great!
Thanks again,
-Ash