### PR TITLE
Add initial support for ESP8266 (xtensa-lx106-elf)

### DIFF
--- a/cross-xtensa-lx106-elf.txt
+++ b/cross-xtensa-lx106-elf.txt
@@ -1,0 +1,16 @@
+[binaries]
+c = 'xtensa-lx106-elf-gcc'
+ar = 'xtensa-lx106-elf-ar'
+as = 'xtensa-lx106-elf-as'
+ld = 'xtensa-lx106-elf-ld'
+strip = 'xtensa-lx106-elf-strip'
+
+[properties]
+c_args = [ '-mlongcalls', '-Os' ]
+
+[host_machine]
+system = 'esp8266'
+cpu_family = 'xtensa'
+cpu = 'xtensa'
+endian = 'little'
+

--- a/newlib/libc/include/machine/ieeefp.h
+++ b/newlib/libc/include/machine/ieeefp.h
@@ -457,6 +457,14 @@
 #define __IEEE_BIG_ENDIAN
 #endif
 
+#if (defined(__XTENSA__))
+#ifdef __XTENSA_EB__
+#define __IEEE_BIG_ENDIAN
+#else
+#define __IEEE_LITTLE_ENDIAN
+#endif
+#endif
+
 #ifdef __AMDGCN__
 #define __IEEE_LITTLE_ENDIAN
 #endif

--- a/newlib/libc/machine/xtensa/machine/core-isa.h
+++ b/newlib/libc/machine/xtensa/machine/core-isa.h
@@ -1,0 +1,459 @@
+/* 
+ * xtensa/config/core-isa.h -- HAL definitions that are dependent on Xtensa
+ *				processor CORE configuration
+ *
+ *  See <xtensa/config/core.h>, which includes this file, for more details.
+ */
+
+/* Xtensa processor core configuration information.
+
+   Copyright (c) 1999-2010 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#ifndef _XTENSA_CORE_CONFIGURATION_H
+#define _XTENSA_CORE_CONFIGURATION_H
+
+
+/****************************************************************************
+	    Parameters Useful for Any Code, USER or PRIVILEGED
+ ****************************************************************************/
+
+/*
+ *  Note:  Macros of the form XCHAL_HAVE_*** have a value of 1 if the option is
+ *  configured, and a value of 0 otherwise.  These macros are always defined.
+ */
+
+
+/*----------------------------------------------------------------------
+				ISA
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_BE			0	/* big-endian byte ordering */
+#define XCHAL_HAVE_WINDOWED		0	/* windowed registers option */
+#define XCHAL_NUM_AREGS			16	/* num of physical addr regs */
+#define XCHAL_NUM_AREGS_LOG2		4	/* log2(XCHAL_NUM_AREGS) */
+#define XCHAL_MAX_INSTRUCTION_SIZE	3	/* max instr bytes (3..8) */
+#define XCHAL_HAVE_DEBUG		1	/* debug option */
+#define XCHAL_HAVE_DENSITY		1	/* 16-bit instructions */
+#define XCHAL_HAVE_LOOPS		0	/* zero-overhead loops */
+#define XCHAL_HAVE_NSA			1	/* NSA/NSAU instructions */
+#define XCHAL_HAVE_MINMAX		0	/* MIN/MAX instructions */
+#define XCHAL_HAVE_SEXT			0	/* SEXT instruction */
+#define XCHAL_HAVE_CLAMPS		0	/* CLAMPS instruction */
+#define XCHAL_HAVE_MUL16		1	/* MUL16S/MUL16U instructions */
+#define XCHAL_HAVE_MUL32		1	/* MULL instruction */
+#define XCHAL_HAVE_MUL32_HIGH		0	/* MULUH/MULSH instructions */
+#define XCHAL_HAVE_DIV32		0	/* QUOS/QUOU/REMS/REMU instructions */
+#define XCHAL_HAVE_L32R			1	/* L32R instruction */
+#define XCHAL_HAVE_ABSOLUTE_LITERALS	1	/* non-PC-rel (extended) L32R */
+#define XCHAL_HAVE_CONST16		0	/* CONST16 instruction */
+#define XCHAL_HAVE_ADDX			1	/* ADDX#/SUBX# instructions */
+#define XCHAL_HAVE_WIDE_BRANCHES	0	/* B*.W18 or B*.W15 instr's */
+#define XCHAL_HAVE_PREDICTED_BRANCHES	0	/* B[EQ/EQZ/NE/NEZ]T instr's */
+#define XCHAL_HAVE_CALL4AND12		0	/* (obsolete option) */
+#define XCHAL_HAVE_ABS			1	/* ABS instruction */
+/*#define XCHAL_HAVE_POPC		0*/	/* POPC instruction */
+/*#define XCHAL_HAVE_CRC		0*/	/* CRC instruction */
+#define XCHAL_HAVE_RELEASE_SYNC		0	/* L32AI/S32RI instructions */
+#define XCHAL_HAVE_S32C1I		0	/* S32C1I instruction */
+#define XCHAL_HAVE_SPECULATION		0	/* speculation */
+#define XCHAL_HAVE_FULL_RESET		1	/* all regs/state reset */
+#define XCHAL_NUM_CONTEXTS		1	/* */
+#define XCHAL_NUM_MISC_REGS		0	/* num of scratch regs (0..4) */
+#define XCHAL_HAVE_TAP_MASTER		0	/* JTAG TAP control instr's */
+#define XCHAL_HAVE_PRID			1	/* processor ID register */
+#define XCHAL_HAVE_EXTERN_REGS		1	/* WER/RER instructions */
+#define XCHAL_HAVE_MP_INTERRUPTS	0	/* interrupt distributor port */
+#define XCHAL_HAVE_MP_RUNSTALL		0	/* core RunStall control port */
+#define XCHAL_HAVE_THREADPTR		0	/* THREADPTR register */
+#define XCHAL_HAVE_BOOLEANS		0	/* boolean registers */
+#define XCHAL_HAVE_CP			0	/* CPENABLE reg (coprocessor) */
+#define XCHAL_CP_MAXCFG			0	/* max allowed cp id plus one */
+#define XCHAL_HAVE_MAC16		0	/* MAC16 package */
+#define XCHAL_HAVE_VECTORFPU2005	0	/* vector floating-point pkg */
+#define XCHAL_HAVE_FP			0	/* floating point pkg */
+#define XCHAL_HAVE_DFP			0	/* double precision FP pkg */
+#define XCHAL_HAVE_DFP_accel		0	/* double precision FP acceleration pkg */
+#define XCHAL_HAVE_VECTRA1		0	/* Vectra I  pkg */
+#define XCHAL_HAVE_VECTRALX		0	/* Vectra LX pkg */
+#define XCHAL_HAVE_HIFIPRO		0	/* HiFiPro Audio Engine pkg */
+#define XCHAL_HAVE_HIFI2		0	/* HiFi2 Audio Engine pkg */
+#define XCHAL_HAVE_CONNXD2		0	/* ConnX D2 pkg */
+
+
+/*----------------------------------------------------------------------
+				MISC
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_WRITEBUFFER_ENTRIES	1	/* size of write buffer */
+#define XCHAL_INST_FETCH_WIDTH		4	/* instr-fetch width in bytes */
+#define XCHAL_DATA_WIDTH		4	/* data width in bytes */
+/*  In T1050, applies to selected core load and store instructions (see ISA): */
+#define XCHAL_UNALIGNED_LOAD_EXCEPTION	1	/* unaligned loads cause exc. */
+#define XCHAL_UNALIGNED_STORE_EXCEPTION	1	/* unaligned stores cause exc.*/
+#define XCHAL_UNALIGNED_LOAD_HW		0	/* unaligned loads work in hw */
+#define XCHAL_UNALIGNED_STORE_HW	0	/* unaligned stores work in hw*/
+
+#define XCHAL_SW_VERSION		800001	/* sw version of this header */
+
+#define XCHAL_CORE_ID			"lx106"	/* alphanum core name
+						   (CoreID) set in the Xtensa
+						   Processor Generator */
+
+#define XCHAL_BUILD_UNIQUE_ID		0x0002B6F6	/* 22-bit sw build ID */
+
+/*
+ *  These definitions describe the hardware targeted by this software.
+ */
+#define XCHAL_HW_CONFIGID0		0xC28CDAFA	/* ConfigID hi 32 bits*/
+#define XCHAL_HW_CONFIGID1		0x1082B6F6	/* ConfigID lo 32 bits*/
+#define XCHAL_HW_VERSION_NAME		"LX3.0.1"	/* full version name */
+#define XCHAL_HW_VERSION_MAJOR		2300	/* major ver# of targeted hw */
+#define XCHAL_HW_VERSION_MINOR		1	/* minor ver# of targeted hw */
+#define XCHAL_HW_VERSION		230001	/* major*100+minor */
+#define XCHAL_HW_REL_LX3		1
+#define XCHAL_HW_REL_LX3_0		1
+#define XCHAL_HW_REL_LX3_0_1		1
+#define XCHAL_HW_CONFIGID_RELIABLE	1
+/*  If software targets a *range* of hardware versions, these are the bounds: */
+#define XCHAL_HW_MIN_VERSION_MAJOR	2300	/* major v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION_MINOR	1	/* minor v of earliest tgt hw */
+#define XCHAL_HW_MIN_VERSION		230001	/* earliest targeted hw */
+#define XCHAL_HW_MAX_VERSION_MAJOR	2300	/* major v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION_MINOR	1	/* minor v of latest tgt hw */
+#define XCHAL_HW_MAX_VERSION		230001	/* latest targeted hw */
+
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_ICACHE_LINESIZE		4	/* I-cache line size in bytes */
+#define XCHAL_DCACHE_LINESIZE		4	/* D-cache line size in bytes */
+#define XCHAL_ICACHE_LINEWIDTH		2	/* log2(I line size in bytes) */
+#define XCHAL_DCACHE_LINEWIDTH		2	/* log2(D line size in bytes) */
+
+#define XCHAL_ICACHE_SIZE		0	/* I-cache size in bytes or 0 */
+#define XCHAL_DCACHE_SIZE		0	/* D-cache size in bytes or 0 */
+
+#define XCHAL_DCACHE_IS_WRITEBACK	0	/* writeback feature */
+#define XCHAL_DCACHE_IS_COHERENT	0	/* MP coherence feature */
+
+#define XCHAL_HAVE_PREFETCH		0	/* PREFCTL register */
+
+
+
+
+/****************************************************************************
+    Parameters Useful for PRIVILEGED (Supervisory or Non-Virtualized) Code
+ ****************************************************************************/
+
+
+#ifndef XTENSA_HAL_NON_PRIVILEGED_ONLY
+
+/*----------------------------------------------------------------------
+				CACHE
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_PIF			1	/* any outbound PIF present */
+
+/*  If present, cache size in bytes == (ways * 2^(linewidth + setwidth)).  */
+
+/*  Number of cache sets in log2(lines per way):  */
+#define XCHAL_ICACHE_SETWIDTH		0
+#define XCHAL_DCACHE_SETWIDTH		0
+
+/*  Cache set associativity (number of ways):  */
+#define XCHAL_ICACHE_WAYS		1
+#define XCHAL_DCACHE_WAYS		1
+
+/*  Cache features:  */
+#define XCHAL_ICACHE_LINE_LOCKABLE	0
+#define XCHAL_DCACHE_LINE_LOCKABLE	0
+#define XCHAL_ICACHE_ECC_PARITY		0
+#define XCHAL_DCACHE_ECC_PARITY		0
+
+/*  Cache access size in bytes (affects operation of SICW instruction):  */
+#define XCHAL_ICACHE_ACCESS_SIZE	1
+#define XCHAL_DCACHE_ACCESS_SIZE	1
+
+/*  Number of encoded cache attr bits (see <xtensa/hal.h> for decoded bits):  */
+#define XCHAL_CA_BITS			4
+
+
+/*----------------------------------------------------------------------
+			INTERNAL I/D RAM/ROMs and XLMI
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_NUM_INSTROM		1	/* number of core instr. ROMs */
+#define XCHAL_NUM_INSTRAM		2	/* number of core instr. RAMs */
+#define XCHAL_NUM_DATAROM		1	/* number of core data ROMs */
+#define XCHAL_NUM_DATARAM		2	/* number of core data RAMs */
+#define XCHAL_NUM_URAM			0	/* number of core unified RAMs*/
+#define XCHAL_NUM_XLMI			1	/* number of core XLMI ports */
+
+/*  Instruction ROM 0:  */
+#define XCHAL_INSTROM0_VADDR		0x40200000
+#define XCHAL_INSTROM0_PADDR		0x40200000
+#define XCHAL_INSTROM0_SIZE		1048576
+#define XCHAL_INSTROM0_ECC_PARITY	0
+
+/*  Instruction RAM 0:  */
+#define XCHAL_INSTRAM0_VADDR		0x40000000
+#define XCHAL_INSTRAM0_PADDR		0x40000000
+#define XCHAL_INSTRAM0_SIZE		1048576
+#define XCHAL_INSTRAM0_ECC_PARITY	0
+
+/*  Instruction RAM 1:  */
+#define XCHAL_INSTRAM1_VADDR		0x40100000
+#define XCHAL_INSTRAM1_PADDR		0x40100000
+#define XCHAL_INSTRAM1_SIZE		1048576
+#define XCHAL_INSTRAM1_ECC_PARITY	0
+
+/*  Data ROM 0:  */
+#define XCHAL_DATAROM0_VADDR		0x3FF40000
+#define XCHAL_DATAROM0_PADDR		0x3FF40000
+#define XCHAL_DATAROM0_SIZE		262144
+#define XCHAL_DATAROM0_ECC_PARITY	0
+
+/*  Data RAM 0:  */
+#define XCHAL_DATARAM0_VADDR		0x3FFC0000
+#define XCHAL_DATARAM0_PADDR		0x3FFC0000
+#define XCHAL_DATARAM0_SIZE		262144
+#define XCHAL_DATARAM0_ECC_PARITY	0
+
+/*  Data RAM 1:  */
+#define XCHAL_DATARAM1_VADDR		0x3FF80000
+#define XCHAL_DATARAM1_PADDR		0x3FF80000
+#define XCHAL_DATARAM1_SIZE		262144
+#define XCHAL_DATARAM1_ECC_PARITY	0
+
+/*  XLMI Port 0:  */
+#define XCHAL_XLMI0_VADDR		0x3FF00000
+#define XCHAL_XLMI0_PADDR		0x3FF00000
+#define XCHAL_XLMI0_SIZE		262144
+#define XCHAL_XLMI0_ECC_PARITY	0
+
+
+/*----------------------------------------------------------------------
+			INTERRUPTS and TIMERS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_INTERRUPTS		1	/* interrupt option */
+#define XCHAL_HAVE_HIGHPRI_INTERRUPTS	1	/* med/high-pri. interrupts */
+#define XCHAL_HAVE_NMI			1	/* non-maskable interrupt */
+#define XCHAL_HAVE_CCOUNT		1	/* CCOUNT reg. (timer option) */
+#define XCHAL_NUM_TIMERS		1	/* number of CCOMPAREn regs */
+#define XCHAL_NUM_INTERRUPTS		15	/* number of interrupts */
+#define XCHAL_NUM_INTERRUPTS_LOG2	4	/* ceil(log2(NUM_INTERRUPTS)) */
+#define XCHAL_NUM_EXTINTERRUPTS		13	/* num of external interrupts */
+#define XCHAL_NUM_INTLEVELS		2	/* number of interrupt levels
+						   (not including level zero) */
+#define XCHAL_EXCM_LEVEL		1	/* level masked by PS.EXCM */
+	/* (always 1 in XEA1; levels 2 .. EXCM_LEVEL are "medium priority") */
+
+/*  Masks of interrupts at each interrupt level:  */
+#define XCHAL_INTLEVEL1_MASK		0x00003FFF
+#define XCHAL_INTLEVEL2_MASK		0x00000000
+#define XCHAL_INTLEVEL3_MASK		0x00004000
+#define XCHAL_INTLEVEL4_MASK		0x00000000
+#define XCHAL_INTLEVEL5_MASK		0x00000000
+#define XCHAL_INTLEVEL6_MASK		0x00000000
+#define XCHAL_INTLEVEL7_MASK		0x00000000
+
+/*  Masks of interrupts at each range 1..n of interrupt levels:  */
+#define XCHAL_INTLEVEL1_ANDBELOW_MASK	0x00003FFF
+#define XCHAL_INTLEVEL2_ANDBELOW_MASK	0x00003FFF
+#define XCHAL_INTLEVEL3_ANDBELOW_MASK	0x00007FFF
+#define XCHAL_INTLEVEL4_ANDBELOW_MASK	0x00007FFF
+#define XCHAL_INTLEVEL5_ANDBELOW_MASK	0x00007FFF
+#define XCHAL_INTLEVEL6_ANDBELOW_MASK	0x00007FFF
+#define XCHAL_INTLEVEL7_ANDBELOW_MASK	0x00007FFF
+
+/*  Level of each interrupt:  */
+#define XCHAL_INT0_LEVEL		1
+#define XCHAL_INT1_LEVEL		1
+#define XCHAL_INT2_LEVEL		1
+#define XCHAL_INT3_LEVEL		1
+#define XCHAL_INT4_LEVEL		1
+#define XCHAL_INT5_LEVEL		1
+#define XCHAL_INT6_LEVEL		1
+#define XCHAL_INT7_LEVEL		1
+#define XCHAL_INT8_LEVEL		1
+#define XCHAL_INT9_LEVEL		1
+#define XCHAL_INT10_LEVEL		1
+#define XCHAL_INT11_LEVEL		1
+#define XCHAL_INT12_LEVEL		1
+#define XCHAL_INT13_LEVEL		1
+#define XCHAL_INT14_LEVEL		3
+#define XCHAL_DEBUGLEVEL		2	/* debug interrupt level */
+#define XCHAL_HAVE_DEBUG_EXTERN_INT	1	/* OCD external db interrupt */
+#define XCHAL_NMILEVEL			3	/* NMI "level" (for use with
+						   EXCSAVE/EPS/EPC_n, RFI n) */
+
+/*  Type of each interrupt:  */
+#define XCHAL_INT0_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT1_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT2_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT3_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT4_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT5_TYPE 	XTHAL_INTTYPE_EXTERN_LEVEL
+#define XCHAL_INT6_TYPE 	XTHAL_INTTYPE_TIMER
+#define XCHAL_INT7_TYPE 	XTHAL_INTTYPE_SOFTWARE
+#define XCHAL_INT8_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT9_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT10_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT11_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT12_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT13_TYPE 	XTHAL_INTTYPE_EXTERN_EDGE
+#define XCHAL_INT14_TYPE 	XTHAL_INTTYPE_NMI
+
+/*  Masks of interrupts for each type of interrupt:  */
+#define XCHAL_INTTYPE_MASK_UNCONFIGURED	0xFFFF8000
+#define XCHAL_INTTYPE_MASK_SOFTWARE	0x00000080
+#define XCHAL_INTTYPE_MASK_EXTERN_EDGE	0x00003F00
+#define XCHAL_INTTYPE_MASK_EXTERN_LEVEL	0x0000003F
+#define XCHAL_INTTYPE_MASK_TIMER	0x00000040
+#define XCHAL_INTTYPE_MASK_NMI		0x00004000
+#define XCHAL_INTTYPE_MASK_WRITE_ERROR	0x00000000
+
+/*  Interrupt numbers assigned to specific interrupt sources:  */
+#define XCHAL_TIMER0_INTERRUPT		6	/* CCOMPARE0 */
+#define XCHAL_TIMER1_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_TIMER2_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_TIMER3_INTERRUPT		XTHAL_TIMER_UNCONFIGURED
+#define XCHAL_NMI_INTERRUPT		14	/* non-maskable interrupt */
+
+/*  Interrupt numbers for levels at which only one interrupt is configured:  */
+#define XCHAL_INTLEVEL3_NUM		14
+/*  (There are many interrupts each at level(s) 1.)  */
+
+
+/*
+ *  External interrupt vectors/levels.
+ *  These macros describe how Xtensa processor interrupt numbers
+ *  (as numbered internally, eg. in INTERRUPT and INTENABLE registers)
+ *  map to external BInterrupt<n> pins, for those interrupts
+ *  configured as external (level-triggered, edge-triggered, or NMI).
+ *  See the Xtensa processor databook for more details.
+ */
+
+/*  Core interrupt numbers mapped to each EXTERNAL interrupt number:  */
+#define XCHAL_EXTINT0_NUM		0	/* (intlevel 1) */
+#define XCHAL_EXTINT1_NUM		1	/* (intlevel 1) */
+#define XCHAL_EXTINT2_NUM		2	/* (intlevel 1) */
+#define XCHAL_EXTINT3_NUM		3	/* (intlevel 1) */
+#define XCHAL_EXTINT4_NUM		4	/* (intlevel 1) */
+#define XCHAL_EXTINT5_NUM		5	/* (intlevel 1) */
+#define XCHAL_EXTINT6_NUM		8	/* (intlevel 1) */
+#define XCHAL_EXTINT7_NUM		9	/* (intlevel 1) */
+#define XCHAL_EXTINT8_NUM		10	/* (intlevel 1) */
+#define XCHAL_EXTINT9_NUM		11	/* (intlevel 1) */
+#define XCHAL_EXTINT10_NUM		12	/* (intlevel 1) */
+#define XCHAL_EXTINT11_NUM		13	/* (intlevel 1) */
+#define XCHAL_EXTINT12_NUM		14	/* (intlevel 3) */
+
+
+/*----------------------------------------------------------------------
+			EXCEPTIONS and VECTORS
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_XEA_VERSION		2	/* Xtensa Exception Architecture
+						   number: 1 == XEA1 (old)
+							   2 == XEA2 (new)
+							   0 == XEAX (extern) */
+#define XCHAL_HAVE_XEA1			0	/* Exception Architecture 1 */
+#define XCHAL_HAVE_XEA2			1	/* Exception Architecture 2 */
+#define XCHAL_HAVE_XEAX			0	/* External Exception Arch. */
+#define XCHAL_HAVE_EXCEPTIONS		1	/* exception option */
+#define XCHAL_HAVE_MEM_ECC_PARITY	0	/* local memory ECC/parity */
+#define XCHAL_HAVE_VECTOR_SELECT	1	/* relocatable vectors */
+#define XCHAL_HAVE_VECBASE		1	/* relocatable vectors */
+#define XCHAL_VECBASE_RESET_VADDR	0x40000000  /* VECBASE reset value */
+#define XCHAL_VECBASE_RESET_PADDR	0x40000000
+#define XCHAL_RESET_VECBASE_OVERLAP	0
+
+#define XCHAL_RESET_VECTOR0_VADDR	0x50000000
+#define XCHAL_RESET_VECTOR0_PADDR	0x50000000
+#define XCHAL_RESET_VECTOR1_VADDR	0x40000080
+#define XCHAL_RESET_VECTOR1_PADDR	0x40000080
+#define XCHAL_RESET_VECTOR_VADDR	0x50000000
+#define XCHAL_RESET_VECTOR_PADDR	0x50000000
+#define XCHAL_USER_VECOFS		0x00000050
+#define XCHAL_USER_VECTOR_VADDR		0x40000050
+#define XCHAL_USER_VECTOR_PADDR		0x40000050
+#define XCHAL_KERNEL_VECOFS		0x00000030
+#define XCHAL_KERNEL_VECTOR_VADDR	0x40000030
+#define XCHAL_KERNEL_VECTOR_PADDR	0x40000030
+#define XCHAL_DOUBLEEXC_VECOFS		0x00000070
+#define XCHAL_DOUBLEEXC_VECTOR_VADDR	0x40000070
+#define XCHAL_DOUBLEEXC_VECTOR_PADDR	0x40000070
+#define XCHAL_INTLEVEL2_VECOFS		0x00000010
+#define XCHAL_INTLEVEL2_VECTOR_VADDR	0x40000010
+#define XCHAL_INTLEVEL2_VECTOR_PADDR	0x40000010
+#define XCHAL_DEBUG_VECOFS		XCHAL_INTLEVEL2_VECOFS
+#define XCHAL_DEBUG_VECTOR_VADDR	XCHAL_INTLEVEL2_VECTOR_VADDR
+#define XCHAL_DEBUG_VECTOR_PADDR	XCHAL_INTLEVEL2_VECTOR_PADDR
+#define XCHAL_NMI_VECOFS		0x00000020
+#define XCHAL_NMI_VECTOR_VADDR		0x40000020
+#define XCHAL_NMI_VECTOR_PADDR		0x40000020
+#define XCHAL_INTLEVEL3_VECOFS		XCHAL_NMI_VECOFS
+#define XCHAL_INTLEVEL3_VECTOR_VADDR	XCHAL_NMI_VECTOR_VADDR
+#define XCHAL_INTLEVEL3_VECTOR_PADDR	XCHAL_NMI_VECTOR_PADDR
+
+
+/*----------------------------------------------------------------------
+				DEBUG
+  ----------------------------------------------------------------------*/
+
+#define XCHAL_HAVE_OCD			1	/* OnChipDebug option */
+#define XCHAL_NUM_IBREAK		1	/* number of IBREAKn regs */
+#define XCHAL_NUM_DBREAK		1	/* number of DBREAKn regs */
+#define XCHAL_HAVE_OCD_DIR_ARRAY	0	/* faster OCD option */
+
+
+/*----------------------------------------------------------------------
+				MMU
+  ----------------------------------------------------------------------*/
+
+/*  See core-matmap.h header file for more details.  */
+
+#define XCHAL_HAVE_TLBS			1	/* inverse of HAVE_CACHEATTR */
+#define XCHAL_HAVE_SPANNING_WAY		1	/* one way maps I+D 4GB vaddr */
+#define XCHAL_SPANNING_WAY		0	/* TLB spanning way number */
+#define XCHAL_HAVE_IDENTITY_MAP		1	/* vaddr == paddr always */
+#define XCHAL_HAVE_CACHEATTR		0	/* CACHEATTR register present */
+#define XCHAL_HAVE_MIMIC_CACHEATTR	1	/* region protection */
+#define XCHAL_HAVE_XLT_CACHEATTR	0	/* region prot. w/translation */
+#define XCHAL_HAVE_PTP_MMU		0	/* full MMU (with page table
+						   [autorefill] and protection)
+						   usable for an MMU-based OS */
+/*  If none of the above last 4 are set, it's a custom TLB configuration.  */
+
+#define XCHAL_MMU_ASID_BITS		0	/* number of bits in ASIDs */
+#define XCHAL_MMU_RINGS			1	/* number of rings (1..4) */
+#define XCHAL_MMU_RING_BITS		0	/* num of bits in RING field */
+
+#endif /* !XTENSA_HAL_NON_PRIVILEGED_ONLY */
+
+
+#endif /* _XTENSA_CORE_CONFIGURATION_H */
+

--- a/newlib/libc/machine/xtensa/memcpy.S
+++ b/newlib/libc/machine/xtensa/memcpy.S
@@ -1,0 +1,289 @@
+/* ANSI C standard library function memcpy.
+
+   Copyright (c) 2002-2008 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+/* If the Xtensa Unaligned Load Exception option is not used, this
+   code can run a few cycles faster by relying on the low address bits
+   being ignored.  However, if the code is then run with an Xtensa ISS
+   client that checks for unaligned accesses, it will produce a lot of
+   warning messages.  Set this flag to disable the use of unaligned
+   accesses and keep the ISS happy.  */
+
+#if XCHAL_UNALIGNED_LOAD_EXCEPTION || 1
+#define UNALIGNED_ADDRESSES_CHECKED 1
+#endif
+
+
+/* void *memcpy (void *dst, const void *src, size_t len)
+
+   The algorithm is as follows:
+
+   If the destination is unaligned, align it by conditionally
+   copying 1- and/or 2-byte pieces.
+
+   If the source is aligned, copy 16 bytes with a loop, and then finish up
+   with 8, 4, 2, and 1-byte copies conditional on the length.
+
+   Else (if source is unaligned), do the same, but use SRC to align the
+   source data.
+
+   This code tries to use fall-through branches for the common
+   case of aligned source and destination and multiple of 4 (or 8) length.  */
+
+
+/* Byte by byte copy.  */
+
+	.text
+	.begin schedule
+	.align	XCHAL_INST_FETCH_WIDTH
+	.literal_position
+__memcpy_aux:
+
+	/* Skip bytes to get proper alignment for three-byte loop */
+.skip XCHAL_INST_FETCH_WIDTH - 3
+
+.Lbytecopy:
+#if XCHAL_HAVE_LOOPS
+	loopnez	a4, 2f
+#else
+	beqz	a4, 2f
+	add	a7, a3, a4	// a7 = end address for source
+#endif
+1:	l8ui	a6, a3, 0
+	addi	a3, a3, 1
+	s8i	a6, a5, 0
+	addi	a5, a5, 1
+#if !XCHAL_HAVE_LOOPS
+	bltu	a3, a7, 1b
+#endif
+2:	leaf_return
+
+
+/* Destination is unaligned.  */
+
+	.align	4
+.Ldst1mod2: // dst is only byte aligned
+
+	/* Do short copies byte-by-byte.  */
+	bltui	a4, 7, .Lbytecopy
+
+	/* Copy 1 byte.  */
+	l8ui	a6, a3, 0
+	addi	a3, a3, 1
+	addi	a4, a4, -1
+	s8i	a6, a5, 0
+	addi	a5, a5, 1
+
+	/* Return to main algorithm if dst is now aligned.  */
+	bbci.l	a5, 1, .Ldstaligned
+
+.Ldst2mod4: // dst has 16-bit alignment
+
+	/* Do short copies byte-by-byte.  */
+	bltui	a4, 6, .Lbytecopy
+
+	/* Copy 2 bytes.  */
+	l8ui	a6, a3, 0
+	l8ui	a7, a3, 1
+	addi	a3, a3, 2
+	addi	a4, a4, -2
+	s8i	a6, a5, 0
+	s8i	a7, a5, 1
+	addi	a5, a5, 2
+
+	/* dst is now aligned; return to main algorithm.  */
+	j	.Ldstaligned
+
+
+	.align	4
+	.global	memcpy
+	.type	memcpy, @function
+memcpy:
+	leaf_entry sp, 16
+	/* a2 = dst, a3 = src, a4 = len */
+
+	mov	a5, a2		// copy dst so that a2 is return value
+	bbsi.l	a2, 0, .Ldst1mod2
+	bbsi.l	a2, 1, .Ldst2mod4
+.Ldstaligned:
+
+	/* Get number of loop iterations with 16B per iteration.  */
+	srli	a7, a4, 4
+
+	/* Check if source is aligned.  */
+	slli 	a8, a3, 30
+	bnez	a8, .Lsrcunaligned
+
+	/* Destination and source are word-aligned, use word copy.  */
+#if XCHAL_HAVE_LOOPS
+	loopnez	a7, 2f
+#else
+	beqz	a7, 2f
+	slli	a8, a7, 4
+	add	a8, a8, a3	// a8 = end of last 16B source chunk
+#endif
+1:	l32i	a6, a3, 0
+	l32i	a7, a3, 4
+	s32i	a6, a5, 0
+	l32i	a6, a3, 8
+	s32i	a7, a5, 4
+	l32i	a7, a3, 12
+	s32i	a6, a5, 8
+	addi	a3, a3, 16
+	s32i	a7, a5, 12
+	addi	a5, a5, 16
+#if !XCHAL_HAVE_LOOPS
+	bltu	a3, a8, 1b
+#endif
+
+	/* Copy any leftover pieces smaller than 16B.  */
+2:	bbci.l	a4, 3, 3f
+
+	/* Copy 8 bytes.  */
+	l32i	a6, a3, 0
+	l32i	a7, a3, 4
+	addi	a3, a3, 8
+	s32i	a6, a5, 0
+	s32i	a7, a5, 4
+	addi	a5, a5, 8
+
+3:	bbsi.l	a4, 2, 4f
+	bbsi.l	a4, 1, 5f
+	bbsi.l	a4, 0, 6f
+	leaf_return
+
+	.align 4
+	/* Copy 4 bytes.  */
+4:	l32i	a6, a3, 0
+	addi	a3, a3, 4
+	s32i	a6, a5, 0
+	addi	a5, a5, 4
+	bbsi.l	a4, 1, 5f
+	bbsi.l	a4, 0, 6f
+	leaf_return
+
+	/* Copy 2 bytes.  */
+5:	l16ui	a6, a3, 0
+	addi	a3, a3, 2
+	s16i	a6, a5, 0
+	addi	a5, a5, 2
+	bbsi.l	a4, 0, 6f
+	leaf_return
+
+	/* Copy 1 byte.  */
+6:	l8ui	a6, a3, 0
+	s8i	a6, a5, 0
+
+.Ldone:
+	leaf_return
+
+
+/* Destination is aligned; source is unaligned.  */
+
+	.align	4
+.Lsrcunaligned:
+	/* Avoid loading anything for zero-length copies.  */
+	beqz	a4, .Ldone
+
+	/* Copy 16 bytes per iteration for word-aligned dst and
+	   unaligned src.  */
+	ssa8	a3		// set shift amount from byte offset
+#if UNALIGNED_ADDRESSES_CHECKED
+	srli    a11, a8, 30     // save unalignment offset for below
+	sub	a3, a3, a11	// align a3
+#endif
+	l32i	a6, a3, 0	// load first word
+#if XCHAL_HAVE_LOOPS
+	loopnez	a7, 2f
+#else
+	beqz	a7, 2f
+	slli	a10, a7, 4
+	add	a10, a10, a3	// a10 = end of last 16B source chunk
+#endif
+1:	l32i	a7, a3, 4
+	l32i	a8, a3, 8
+	src_b	a6, a6, a7
+	s32i	a6, a5, 0
+	l32i	a9, a3, 12
+	src_b	a7, a7, a8
+	s32i	a7, a5, 4
+	l32i	a6, a3, 16
+	src_b	a8, a8, a9
+	s32i	a8, a5, 8
+	addi	a3, a3, 16
+	src_b	a9, a9, a6
+	s32i	a9, a5, 12
+	addi	a5, a5, 16
+#if !XCHAL_HAVE_LOOPS
+	bltu	a3, a10, 1b
+#endif
+
+2:	bbci.l	a4, 3, 3f
+
+	/* Copy 8 bytes.  */
+	l32i	a7, a3, 4
+	l32i	a8, a3, 8
+	src_b	a6, a6, a7
+	s32i	a6, a5, 0
+	addi	a3, a3, 8
+	src_b	a7, a7, a8
+	s32i	a7, a5, 4
+	addi	a5, a5, 8
+	mov	a6, a8
+
+3:	bbci.l	a4, 2, 4f
+
+	/* Copy 4 bytes.  */
+	l32i	a7, a3, 4
+	addi	a3, a3, 4
+	src_b	a6, a6, a7
+	s32i	a6, a5, 0
+	addi	a5, a5, 4
+	mov	a6, a7
+4:
+#if UNALIGNED_ADDRESSES_CHECKED
+	add	a3, a3, a11	// readjust a3 with correct misalignment
+#endif
+	bbsi.l	a4, 1, 5f
+	bbsi.l	a4, 0, 6f
+	leaf_return
+
+	/* Copy 2 bytes.  */
+5:	l8ui	a6, a3, 0
+	l8ui	a7, a3, 1
+	addi	a3, a3, 2
+	s8i	a6, a5, 0
+	s8i	a7, a5, 1
+	addi	a5, a5, 2
+	bbsi.l	a4, 0, 6f
+	leaf_return
+
+	/* Copy 1 byte.  */
+6:	l8ui	a6, a3, 0
+	s8i	a6, a5, 0
+	leaf_return
+
+	.end schedule
+
+	.size	memcpy, . - memcpy

--- a/newlib/libc/machine/xtensa/memset.S
+++ b/newlib/libc/machine/xtensa/memset.S
@@ -1,0 +1,170 @@
+/* ANSI C standard library function memset.
+
+   Copyright (c) 2001-2008 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+/* void *memset (void *dst, int c, size_t length)
+
+   The algorithm is as follows:
+
+   Create a word with c in all byte positions.
+
+   If the destination is aligned, set 16B chunks with a loop, and then
+   finish up with 8B, 4B, 2B, and 1B stores conditional on the length.
+
+   If the destination is unaligned, align it by conditionally
+   setting 1B and/or 2B and then go to aligned case.
+
+   This code tries to use fall-through branches for the common
+   case of an aligned destination (except for the branches to
+   the alignment labels).  */
+
+
+/* Byte-by-byte set.  */
+
+	.text
+	.begin schedule
+	.align	XCHAL_INST_FETCH_WIDTH
+	.literal_position
+__memset_aux:
+
+	/* Skip bytes to get proper alignment for three-byte loop */
+.skip XCHAL_INST_FETCH_WIDTH - 3
+
+.Lbyteset:
+#if XCHAL_HAVE_LOOPS
+	loopnez	a4, 2f
+#else
+	beqz	a4, 2f
+	add	a6, a5, a4	// a6 = ending address
+#endif
+1:	s8i	a3, a5, 0
+	addi	a5, a5, 1
+#if !XCHAL_HAVE_LOOPS
+	bltu	a5, a6, 1b
+#endif
+2:	leaf_return
+
+
+/* Destination is unaligned.  */
+
+	.align	4
+
+.Ldst1mod2: // dst is only byte aligned
+
+	/* Do short sizes byte-by-byte.  */
+	bltui	a4, 8, .Lbyteset
+
+	/* Set 1 byte.  */
+	s8i	a3, a5, 0
+	addi	a5, a5, 1
+	addi	a4, a4, -1
+
+	/* Now retest if dst is aligned.  */
+	_bbci.l	a5, 1, .Ldstaligned
+
+.Ldst2mod4: // dst has 16-bit alignment
+
+	/* Do short sizes byte-by-byte.  */
+	bltui	a4, 8, .Lbyteset
+
+	/* Set 2 bytes.  */
+	s16i	a3, a5, 0
+	addi	a5, a5, 2
+	addi	a4, a4, -2
+
+	/* dst is now aligned; return to main algorithm */
+	j	.Ldstaligned
+
+
+	.align	4
+	.global	memset
+	.type	memset, @function
+memset:
+	leaf_entry sp, 16
+	/* a2 = dst, a3 = c, a4 = length */
+
+	/* Duplicate character into all bytes of word.  */
+	extui	a3, a3, 0, 8
+	slli	a7, a3, 8
+	or	a3, a3, a7
+	slli	a7, a3, 16
+	or	a3, a3, a7
+
+	mov	a5, a2		// copy dst so that a2 is return value
+
+	/* Check if dst is unaligned.  */
+	_bbsi.l	a2, 0, .Ldst1mod2
+	_bbsi.l	a2, 1, .Ldst2mod4
+.Ldstaligned:
+
+	/* Get number of loop iterations with 16B per iteration.  */
+	srli	a7, a4, 4
+
+	/* Destination is word-aligned.  */
+#if XCHAL_HAVE_LOOPS
+	loopnez	a7, 2f
+#else
+	beqz	a7, 2f
+	slli	a6, a7, 4
+	add	a6, a6, a5	// a6 = end of last 16B chunk
+#endif
+	/* Set 16 bytes per iteration.  */
+1:	s32i	a3, a5, 0
+	s32i	a3, a5, 4
+	s32i	a3, a5, 8
+	s32i	a3, a5, 12
+	addi	a5, a5, 16
+#if !XCHAL_HAVE_LOOPS
+	bltu	a5, a6, 1b
+#endif
+
+	/* Set any leftover pieces smaller than 16B.  */
+2:	bbci.l	a4, 3, 3f
+
+	/* Set 8 bytes.  */
+	s32i	a3, a5, 0
+	s32i	a3, a5, 4
+	addi	a5, a5, 8
+
+3:	bbci.l	a4, 2, 4f
+
+	/* Set 4 bytes.  */
+	s32i	a3, a5, 0
+	addi	a5, a5, 4
+
+4:	bbci.l	a4, 1, 5f
+
+	/* Set 2 bytes.  */
+	s16i	a3, a5, 0
+	addi	a5, a5, 2
+
+5:	bbci.l	a4, 0, 6f
+
+	/* Set 1 byte.  */
+	s8i	a3, a5, 0
+6:	leaf_return
+
+	.end schedule
+
+	.size	memset, . - memset

--- a/newlib/libc/machine/xtensa/meson.build
+++ b/newlib/libc/machine/xtensa/meson.build
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright © 2019 Jonathan McDowell
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,73 +32,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-libm_machine_dirs = {
-		      'aarch64' : 'aarch64',
-		      'arm' : 'arm',
-		      'i386' : 'i386',
-		      'i486' : 'i386',
-		      'i586' : 'i386',
-		      'i686' : 'i386',
-		      'nds32' : 'nds32',
-		      'riscv' : 'riscv',
-		      'riscv64' : 'riscv',
-		      'spu' : 'spu',
-		      'xtensa': 'xtensa',
-		    }
 
-libdirs = ['math', 'common', 'complex']
-
-libnames = libdirs
-
-need_generic_fenv = true
-
-if libm_machine_dirs.has_key(host_cpu)
-  libm_machine_dir = join_paths('machine', libm_machine_dirs[host_cpu])
-  libdirs = [libm_machine_dir] + libdirs
-  libnames = ['machine'] + libnames
-  if run_command('test', '-f', join_paths(libm_machine_dir, 'fegetenv.c')).returncode() == 0
-    need_generic_fenv = false
-  endif
-else
-  warning('No libm machine directory for cpu ' + host_cpu)
-endif
-
-if need_generic_fenv
-  libdirs = ['fenv'] + libdirs
-  libnames = ['fenv'] + libnames
-endif
-
-math_inc = [include_directories('common'), inc]
-
-foreach libdir : libdirs
-  subdir(libdir)
-endforeach
+srcs_machine = [
+  'memcpy.S',
+  'memset.S',
+  'setjmp.S',
+  'strcmp.S',
+  'strcpy.S',
+  'strlen.S',
+  'strncpy.S',
+]
 
 foreach target : targets
-  value = get_variable('target_' + target)
-  libobjs = []
-
-  foreach libname : libnames
-    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
-  endforeach
-
-  instdir = join_paths(get_option('libdir'), value[0])
-
-  if target == ''
-    libm_name = 'm'
-  else
-    libm_name = join_paths(target, 'libm')
-  endif
-
-  set_variable('lib_m' + target,
-	       static_library(libm_name,
-			      install : true,
-			      install_dir : instdir,
-			      pic: false,
-			      objects : libobjs))
+	value = get_variable('target_' + target)
+	set_variable('lib_machine' + target,
+		static_library('machine' + target,
+			srcs_machine,
+			pic: false,
+			include_directories: inc,
+			c_args: value[1] + ['-fno-builtin']))
 endforeach
-
-if enable_tests
-  subdir('test')
-endif
-

--- a/newlib/libc/machine/xtensa/setjmp.S
+++ b/newlib/libc/machine/xtensa/setjmp.S
@@ -1,0 +1,260 @@
+/* setjmp/longjmp functions for Xtensa.
+
+   Copyright (c) 2001-2006 by Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+/* Windowed ABI:
+
+   This implementation relies heavily on the Xtensa register window
+   mechanism.  Setjmp flushes all the windows except its own to the
+   stack and then copies registers from the save areas on the stack
+   into the jmp_buf structure, along with the return address of the call
+   to setjmp.  Longjmp invalidates all the windows except its own, and
+   then sets things up so that it will return to the right place,
+   using a window underflow to automatically restore the registers.
+
+   Note that it would probably be sufficient to only copy the
+   registers from setjmp's caller into jmp_buf.  However, we also copy
+   the save area located at the stack pointer of setjmp's caller.
+   This save area will typically remain intact until the longjmp call.
+   The one exception is when there is an intervening alloca in
+   setjmp's caller.  This is certainly an unusual situation and is
+   likely to cause problems in any case (the storage allocated on the
+   stack cannot be safely accessed following the longjmp).  As bad as
+   it is, on most systems this situation would not necessarily lead to
+   a catastrophic failure.  If we did not preserve the extra save area
+   on Xtensa, however, it would.  When setjmp's caller returns after a
+   longjmp, there will be a window underflow; an invalid return
+   address or stack pointer in the save area will almost certainly
+   lead to a crash.  Keeping a copy of the extra save area in the
+   jmp_buf avoids this with only a small additional cost.  If setjmp
+   and longjmp are ever time-critical, this could be removed.
+
+
+   Call0 ABI:
+
+   Much like other ABIs, this version just saves the necessary registers
+   to the stack and restores them later.  Much less needs to be done.  */
+
+#include "xtensa-asm.h"
+
+#define SYS_nop	0
+
+
+#if XCHAL_HAVE_WINDOWED && !__XTENSA_CALL0_ABI__
+
+/* int setjmp (jmp_buf env) */
+
+	.text
+	.align	4
+	.literal_position
+	.global	setjmp
+	.type	setjmp, @function
+setjmp:
+	entry	sp, 16
+
+	/* Flush registers.  */
+	mov	a4, a2			// save a2 (jmp_buf)
+	movi	a2, SYS_nop
+	syscall
+	mov	a2, a4			// restore a2
+
+	/* Copy the register save area at (sp - 16).  */
+	addi	a5, a1, -16
+	l32i	a3, a5, 0
+	l32i	a4, a5, 4
+	s32i	a3, a2, 0
+	s32i	a4, a2, 4
+	l32i	a3, a5, 8
+	l32i	a4, a5, 12
+	s32i	a3, a2, 8
+	s32i	a4, a2, 12
+
+	/* Copy 0-8 words from the register overflow area.  */
+	extui	a3, a0, 30, 2
+	blti	a3, 2, .Lendsj
+	l32i	a7, a1, 4
+	slli	a4, a3, 4
+	sub	a5, a7, a4
+	addi	a6, a2, 16
+	addi	a7, a7, -16		// a7 = end of register overflow area
+.Lsjloop:
+	l32i	a3, a5, 0
+	l32i	a4, a5, 4
+	s32i	a3, a6, 0
+	s32i	a4, a6, 4
+	l32i	a3, a5, 8
+	l32i	a4, a5, 12
+	s32i	a3, a6, 8
+	s32i	a4, a6, 12
+	addi	a5, a5, 16
+	addi	a6, a6, 16
+	blt	a5, a7, .Lsjloop
+.Lendsj:
+
+	/* Copy the register save area at sp.  */
+	l32i	a3, a1, 0
+	l32i	a4, a1, 4
+	s32i	a3, a2, 48
+	s32i	a4, a2, 52
+	l32i	a3, a1, 8
+	l32i	a4, a1, 12
+	s32i	a3, a2, 56
+	s32i	a4, a2, 60
+
+	/* Save the return address, including the window size bits.  */
+	s32i	a0, a2, 64
+
+	movi	a2, 0
+	retw
+	.size	setjmp, . - setjmp
+
+
+/* void longjmp (jmp_buf env, int val) */
+
+	.align	4
+	.literal_position
+	.global	longjmp
+	.type	longjmp, @function
+longjmp:
+	entry	sp, 16
+	/*  a2 == &env, a3 == val  */
+
+#if XCHAL_MAYHAVE_ERRATUM_XEA1KWIN
+  /* Using this register triggers early any overflow that a kernel-mode
+     level-one interrupt might otherwise cause.  */
+# define AR_WB	a15
+#else
+  /* Using this register is more efficient; it triggers less overflows.  */
+# define AR_WB	a5
+#endif
+	/* Invalidate all but the current window;
+	   set WindowStart to (1 << WindowBase).  */
+	rsr	AR_WB, WINDOWBASE
+	movi	a4, 1
+	ssl	AR_WB
+	sll	a4, a4
+	wsr	a4, WINDOWSTART
+	rsync
+
+	/* Return to the return address of the setjmp, using the
+	   window size bits from the setjmp call so that the caller
+	   will be able to find the return value that we put in a2.  */
+
+	l32i	a0, a2, 64
+
+	/* Copy the first 4 saved registers from jmp_buf into the save area
+	   at the current sp so that the values will be restored to registers
+	   when longjmp returns.  */
+
+	addi	a7, a1, -16
+	l32i	a4, a2, 0
+	l32i	a5, a2, 4
+	s32i	a4, a7, 0
+	s32i	a5, a7, 4
+	l32i	a4, a2, 8
+	l32i	a5, a2, 12
+	s32i	a4, a7, 8
+	s32i	a5, a7, 12
+
+	/* Copy the remaining 0-8 saved registers.  */
+	extui	a7, a0, 30, 2
+	blti	a7, 2, .Lendlj
+	l32i	a8, a2, 52
+	slli	a4, a7, 4
+	sub	a6, a8, a4
+	addi	a5, a2, 16
+	addi	a8, a8, -16		// a8 = end of register overflow area
+.Lljloop:
+	l32i	a7, a5, 0
+	l32i	a4, a5, 4
+	s32i	a7, a6, 0
+	s32i	a4, a6, 4
+	l32i	a7, a5, 8
+	l32i	a4, a5, 12
+	s32i	a7, a6, 8
+	s32i	a4, a6, 12
+	addi	a5, a5, 16
+	addi	a6, a6, 16
+	blt	a6, a8, .Lljloop
+.Lendlj:
+
+	/* The 4 words saved from the register save area at the target's
+	   sp are copied back to the target procedure's save area.  The
+	   only point of this is to prevent a catastrophic failure in
+	   case the contents were moved by an alloca after calling
+	   setjmp.  This is a bit paranoid but it doesn't cost much.  */
+
+	l32i	a7, a2, 4		// load the target stack pointer
+	addi	a7, a7, -16		// find the destination save area
+	l32i	a4, a2, 48
+	l32i	a5, a2, 52
+	s32i	a4, a7, 0
+	s32i	a5, a7, 4
+	l32i	a4, a2, 56
+	l32i	a5, a2, 60
+	s32i	a4, a7, 8
+	s32i	a5, a7, 12
+
+	/* Return val ? val : 1.  */
+	movi	a2, 1
+	movnez	a2, a3, a3
+
+	retw
+	.size	longjmp, . - longjmp
+
+#else /* CALL0 ABI */
+
+	.text
+	.align	4
+	.literal_position
+	.global	setjmp
+	.type	setjmp, @function
+setjmp:
+	s32i	a0, a2, 0
+	s32i	a1, a2, 4
+	s32i	a12, a2, 8
+	s32i	a13, a2, 12
+	s32i	a14, a2, 16
+	s32i	a15, a2, 20
+	movi	a2, 0
+	ret
+	.size	setjmp, . - setjmp
+
+	.align	4
+	.literal_position
+	.global	longjmp
+	.type	longjmp, @function
+longjmp:
+	l32i	a0, a2, 0
+	l32i	a12, a2, 8
+	l32i	a13, a2, 12
+	l32i	a14, a2, 16
+	l32i	a15, a2, 20
+	l32i	a1, a2, 4
+	/* Return val ? val : 1.  */
+	movi	a2, 1
+	movnez	a2, a3, a3
+
+	ret
+	.size	longjmp, .-longjmp
+
+#endif /* CALL0 ABI */

--- a/newlib/libc/machine/xtensa/strcmp.S
+++ b/newlib/libc/machine/xtensa/strcmp.S
@@ -1,0 +1,778 @@
+/* ANSI C standard library function strcmp.
+
+   Copyright (c) 2001-20012 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+#define MASK4 0x40404040
+
+
+#if XCHAL_HAVE_L32R
+	.literal .Lmask0, MASK0
+	.literal .Lmask1, MASK1
+	.literal .Lmask2, MASK2
+	.literal .Lmask3, MASK3
+	.literal .Lmask4, MASK4
+#endif /* XCHAL_HAVE_L32R */
+
+	.text
+	.align	4
+	.literal_position
+	.global	strcmp
+	.type	strcmp, @function
+strcmp:
+
+#if XCHAL_HAVE_L32R && XCHAL_HAVE_LOOPS && XCHAL_HAVE_DENSITY && __XTENSA_EL__ && XCHAL_HAVE_FLIX3
+/*  Fast version for FLIX3 Little Endian */
+
+
+	leaf_entry sp, 16
+	/* a2 = s1, a3 = s2 */
+
+	l8ui	a8, a2, 0	// byte 0 from s1
+	l8ui	a9, a3, 0	// byte 0 from s2
+	movi	a10, 3		// mask
+	movi	a5, 0xfffffffc
+	or	a11, a2, a3
+	l32r	a4, .Lmask0	// mask for byte 0
+	l32r	a7, .Lmask4
+	addi    a3, a3, -8
+	addi    a2, a2, -8
+	and	a5, a5, a2
+	bne.w18	a8, a9, .Lretdiff
+	l32i	a8, a5, 8	// get word from aligned variant of s1
+
+	bany.w18	a11, a10, .Lnot_aligned
+
+/* s1 is word-aligned; s2 is word-aligned.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.  */
+
+/* New algorithm, relying on the fact that all normal ASCII is between
+   32 and 127.
+
+   Rather than check all bytes for zero:
+   Take one word (4 bytes).  Call it w1.
+   Shift w1 left by one into w1'.
+   Or w1 and w1'.  For all normal ASCII bit 6 will be 1; for zero it won't.
+   Check that all 4 bit 6's (one for each byte) are one:
+   If they are, we are definitely not done.
+   If they are not, we are probably done, but need to check for zero.  */
+
+.Laligned:
+	/* Loop forever */
+1:
+	loop	a0, .Laligned_done
+
+	/* First unrolled loop body.  */
+	l32i	a9, a3, 8	// get word from s2
+	addi	a3, a3, 8	// advance s2 pointer
+	slli	a5, a8, 1
+	or	a10, a8, a5
+	{l32i	a11, a2, 12	// get word from s1+4
+	bne.w18	a8, a9, .Lwne2}
+	l32i	a9, a3, 4	// get word from s2+4
+	bnall.w18	a10, a7, .Lprobeq
+
+	/* Second unrolled loop body.  */
+	slli	a5, a11, 1
+	or	a10, a11, a5
+	addi	a2, a2, 8	// advance s1 pointer
+        mov	a8, a11
+	bne.w18	a11, a9, .Lwne2
+	l32i	a8, a2, 8	// get word from s1
+	bnall.w18	a10, a7, .Lprobeq2
+
+.Laligned_done:
+	l32i	a8, a2, 8	// get word from s1
+	j     	1b
+
+.Lnot_aligned:
+	xor	a11, a2, a3	// compare low two bits of s1 and s2
+	bany	a11, a10, .Lunaligned	// if they have different alignment
+
+	/* s1/s2 are not word-aligned.  */
+	movi	a5, 0xfffffffc
+	addi	a2, a2, 1	// advance s1
+	beqz	a9, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	and     a6, a2, a5
+	l32i	a8, a6, 8	// get word from s1
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 8	// byte 1 from s1
+	l8ui	a9, a3, 8	// byte 1 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	and     a6, a2, a5
+	l32i	a8, a6, 8	// get word from s1
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 8	// byte 2 from s1
+	l8ui	a9, a3, 8	// byte 2 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	l32i	a8, a2, 8	// get word from s1
+	j	.Laligned
+
+/* s1 and s2 have different alignment.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.
+
+   Note: It is important for this unaligned case to come before the
+   code for aligned strings, because otherwise some of the branches
+   above cannot reach and have to be transformed to branches around
+   jumps.  The unaligned code is smaller and the branches can reach
+   over it.  */
+
+.Lunaligned:
+	movi.n	a8, 0		// set up for the maximum loop count
+	loop	a8, .Lretdiff	// loop forever (almost anyway)
+	l8ui	a8, a2, 8
+	l8ui	a9, a3, 8
+	addi	a2, a2, 1
+	bne	a8, a9, .Lretdiff
+	addi	a3, a3, 1
+	beqz	a8, .Lretdiff
+.Lretdiff:
+	sub	a2, a8, a9
+	leaf_return
+
+
+.Lprobeq2:
+	/* Adjust pointers to account for the loop unrolling.  */
+        mov	a8, a11
+	addi	a2, a2, -4
+	addi	a3, a3, 4
+
+	/* align (0 mod 4) */
+.Lprobeq:
+	/* Words are probably equal, but check for sure.
+	   If not, loop over the rest of string using normal algorithm.  */
+
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+	l32r	a5, .Lmask1	// mask for byte 1
+	l32r	a6, .Lmask2	// mask for byte 2
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	l32r	a7, .Lmask3	// mask for byte 3
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	bnone	a8, a7, .Leq	// if byte 3 is zero
+	/* align (1 mod 4) */
+	addi.n	a2, a2, 12	// advance s1 pointer
+	addi.n	a3, a3, 4	// advance s2 pointer
+	/* align (1 mod 4) or (2 mod 4) */
+1:
+	loop	a0, .Lend	// loop forever (a4 is bigger than max iters)
+
+	l32i	a11, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	addi	a2, a2, 4	// advance s1 pointer
+	bne	a11, a9, .Lwne
+	bnone	a11, a4, .Leq	// if byte 0 is zero
+	bnone	a11, a5, .Leq	// if byte 1 is zero
+	bnone	a11, a6, .Leq	// if byte 2 is zero
+	bnone	a11, a7, .Leq	// if byte 3 is zero
+	addi	a3, a3, 4	// advance s2 pointer
+.Lend:
+	j	1b
+
+	/* Words are equal; some byte is zero.  */
+.Leq:	movi	a2, 0		// return equal
+	leaf_return
+
+.Lwne2:	/* Words are not equal.  On big-endian processors, if none of the
+	   bytes are zero, the return value can be determined by a simple
+	   comparison.  */
+.Lwne:	/* Words are not equal.  */
+	xor	a2, a8, a9	// get word with nonzero in byte that differs
+	extui	a10, a8, 0, 8
+	extui	a11, a9, 0, 8
+	movi	a5, MASK1	// mask for byte 1
+	bany.w18	a2, a4, .Ldiff0	// if byte 0 differs
+
+	bnone.w18	a8, a4, .Leq	// if byte 0 is zero
+	movi	a6, MASK2	// mask for byte 2
+	bany.w18	a2, a5, .Ldiff1	// if byte 1 differs
+	extui	a10, a8, 24, 8
+	bnone.w18	a8, a5, .Leq	// if byte 1 is zero
+	extui	a11, a9, 24, 8
+	bany.w18	a2, a6, .Ldiff2	// if byte 2 differs
+	sub	a2, a10, a11
+	bnone.w18	a8, a6, .Leq	// if byte 2 is zero
+	/* Little-endian is a little more difficult because can't subtract
+	   whole words.  */
+.Ldiff3:
+	/* Bytes 0-2 are equal; byte 3 is different.
+	   For little-endian need to have a sign bit for the difference.  */
+	leaf_return
+.Ldiff0:
+	/* Byte 0 is different.  */
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff1:
+	/* Byte 0 is equal; byte 1 is different.  */
+	extui	a10, a8, 8, 8
+	extui	a11, a9, 8, 8
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff2:
+	/* Bytes 0-1 are equal; byte 2 is different.  */
+	extui	a10, a8, 16, 8
+	extui	a11, a9, 16, 8
+	sub	a2, a10, a11
+	leaf_return
+
+#else
+#if XCHAL_HAVE_L32R && XCHAL_HAVE_LOOPS && XCHAL_HAVE_DENSITY && __XTENSA_EL__ && XCHAL_HAVE_PDX4
+/*  Fast version for FLIX3 Little Endian */
+
+
+	leaf_entry sp, 16
+	/* a2 = s1, a3 = s2 */
+
+	l8ui	a8, a2, 0	// byte 0 from s1
+	l8ui	a9, a3, 0	// byte 0 from s2
+	movi	a10, 3		// mask
+	movi	a5, 0xfffffffc
+	or	a11, a2, a3
+	l32r	a4, .Lmask0	// mask for byte 0
+	l32r	a7, .Lmask4
+	addi    a3, a3, -8
+	addi    a2, a2, -8
+	and	a5, a5, a2
+	bne.w15	a8, a9, .Lretdiff
+	l32i	a8, a5, 8	// get word from aligned variant of s1
+
+	bany.w15	a11, a10, .Lnot_aligned
+
+/* s1 is word-aligned; s2 is word-aligned.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.  */
+
+/* New algorithm, relying on the fact that all normal ASCII is between
+   32 and 127.
+
+   Rather than check all bytes for zero:
+   Take one word (4 bytes).  Call it w1.
+   Shift w1 left by one into w1'.
+   Or w1 and w1'.  For all normal ASCII bit 6 will be 1; for zero it won't.
+   Check that all 4 bit 6's (one for each byte) are one:
+   If they are, we are definitely not done.
+   If they are not, we are probably done, but need to check for zero.  */
+
+.Laligned:
+	/* Loop forever */
+1:
+	loop	a0, .Laligned_done
+
+	/* First unrolled loop body.  */
+	l32i	a9, a3, 8	// get word from s2
+	addi	a3, a3, 8	// advance s2 pointer
+	slli	a5, a8, 1
+	or	a10, a8, a5
+	{
+	bne.w15	a8, a9, .Lwne2
+	l32i	a11, a2, 12	// get word from s1+4
+	nop
+	nop
+	}
+	l32i	a9, a3, 4	// get word from s2+4
+	bnall.w15	a10, a7, .Lprobeq
+
+	/* Second unrolled loop body.  */
+	slli	a5, a11, 1
+	or	a10, a11, a5
+	addi	a2, a2, 8	// advance s1 pointer
+        mov	a8, a11
+	bne.w15	a11, a9, .Lwne2
+	l32i	a8, a2, 8	// get word from s1
+	bnall.w15	a10, a7, .Lprobeq2
+
+.Laligned_done:
+	l32i	a8, a2, 8	// get word from s1
+	j     	1b
+
+.Lnot_aligned:
+	xor	a11, a2, a3	// compare low two bits of s1 and s2
+	bany	a11, a10, .Lunaligned	// if they have different alignment
+
+	/* s1/s2 are not word-aligned.  */
+	movi	a5, 0xfffffffc
+	addi	a2, a2, 1	// advance s1
+	beqz	a9, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	and     a6, a2, a5
+	l32i	a8, a6, 8	// get word from s1
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 8	// byte 1 from s1
+	l8ui	a9, a3, 8	// byte 1 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	and     a6, a2, a5
+	l32i	a8, a6, 8	// get word from s1
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 8	// byte 2 from s1
+	l8ui	a9, a3, 8	// byte 2 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	l32i	a8, a2, 8	// get word from s1
+	j	.Laligned
+
+/* s1 and s2 have different alignment.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.
+
+   Note: It is important for this unaligned case to come before the
+   code for aligned strings, because otherwise some of the branches
+   above cannot reach and have to be transformed to branches around
+   jumps.  The unaligned code is smaller and the branches can reach
+   over it.  */
+
+.Lunaligned:
+	movi.n	a8, 0		// set up for the maximum loop count
+	loop	a8, .Lretdiff	// loop forever (almost anyway)
+	l8ui	a8, a2, 8
+	l8ui	a9, a3, 8
+	addi	a2, a2, 1
+	bne	a8, a9, .Lretdiff
+	addi	a3, a3, 1
+	beqz	a8, .Lretdiff
+.Lretdiff:
+	sub	a2, a8, a9
+	leaf_return
+
+
+.Lprobeq2:
+	/* Adjust pointers to account for the loop unrolling.  */
+        mov	a8, a11
+	addi	a2, a2, -4
+	addi	a3, a3, 4
+
+	/* align (0 mod 4) */
+.Lprobeq:
+	/* Words are probably equal, but check for sure.
+	   If not, loop over the rest of string using normal algorithm.  */
+
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+	l32r	a5, .Lmask1	// mask for byte 1
+	l32r	a6, .Lmask2	// mask for byte 2
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	l32r	a7, .Lmask3	// mask for byte 3
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	bnone	a8, a7, .Leq	// if byte 3 is zero
+	/* align (1 mod 4) */
+	addi.n	a2, a2, 12	// advance s1 pointer
+	addi.n	a3, a3, 4	// advance s2 pointer
+	/* align (1 mod 4) or (2 mod 4) */
+1:
+	loop	a0, .Lend	// loop forever (a4 is bigger than max iters)
+
+	l32i	a11, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	addi	a2, a2, 4	// advance s1 pointer
+	bne	a11, a9, .Lwne
+	bnone	a11, a4, .Leq	// if byte 0 is zero
+	bnone	a11, a5, .Leq	// if byte 1 is zero
+	bnone	a11, a6, .Leq	// if byte 2 is zero
+	bnone	a11, a7, .Leq	// if byte 3 is zero
+	addi	a3, a3, 4	// advance s2 pointer
+.Lend:
+	j	1b
+
+	/* Words are equal; some byte is zero.  */
+.Leq:	movi	a2, 0		// return equal
+	leaf_return
+
+.Lwne2:	/* Words are not equal.  On big-endian processors, if none of the
+	   bytes are zero, the return value can be determined by a simple
+	   comparison.  */
+.Lwne:	/* Words are not equal.  */
+	xor	a2, a8, a9	// get word with nonzero in byte that differs
+	extui	a10, a8, 0, 8
+	extui	a11, a9, 0, 8
+	movi	a5, MASK1	// mask for byte 1
+	bany.w15	a2, a4, .Ldiff0	// if byte 0 differs
+
+	bnone.w15	a8, a4, .Leq	// if byte 0 is zero
+	movi	a6, MASK2	// mask for byte 2
+	bany.w15	a2, a5, .Ldiff1	// if byte 1 differs
+	extui	a10, a8, 24, 8
+	bnone.w15	a8, a5, .Leq	// if byte 1 is zero
+	extui	a11, a9, 24, 8
+	bany.w15	a2, a6, .Ldiff2	// if byte 2 differs
+	sub	a2, a10, a11
+	bnone.w15	a8, a6, .Leq	// if byte 2 is zero
+	/* Little-endian is a little more difficult because can't subtract
+	   whole words.  */
+.Ldiff3:
+	/* Bytes 0-2 are equal; byte 3 is different.
+	   For little-endian need to have a sign bit for the difference.  */
+	leaf_return
+.Ldiff0:
+	/* Byte 0 is different.  */
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff1:
+	/* Byte 0 is equal; byte 1 is different.  */
+	extui	a10, a8, 8, 8
+	extui	a11, a9, 8, 8
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff2:
+	/* Bytes 0-1 are equal; byte 2 is different.  */
+	extui	a10, a8, 16, 8
+	extui	a11, a9, 16, 8
+	sub	a2, a10, a11
+	leaf_return
+
+
+#else /* Not FLIX3 */
+	leaf_entry sp, 16
+	/* a2 = s1, a3 = s2 */
+
+	l8ui	a8, a2, 0	// byte 0 from s1
+	l8ui	a9, a3, 0	// byte 0 from s2
+	movi	a10, 3		// mask
+	bne	a8, a9, .Lretdiff
+
+	or	a11, a2, a3
+	bnone	a11, a10, .Laligned
+
+	xor	a11, a2, a3	// compare low two bits of s1 and s2
+	bany	a11, a10, .Lunaligned	// if they have different alignment
+
+	/* s1/s2 are not word-aligned.  */
+	addi	a2, a2, 1	// advance s1
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 0	// byte 1 from s1
+	l8ui	a9, a3, 0	// byte 1 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	bnone	a2, a10, .Laligned // if s1/s2 now aligned
+	l8ui	a8, a2, 0	// byte 2 from s1
+	l8ui	a9, a3, 0	// byte 2 from s2
+	addi	a2, a2, 1	// advance s1
+	bne	a8, a9, .Lretdiff // if different, return difference
+	beqz	a8, .Leq	// bytes equal, if zero, strings are equal
+	addi	a3, a3, 1	// advance s2
+	j	.Laligned
+
+/* s1 and s2 have different alignment.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.
+
+   Note: It is important for this unaligned case to come before the
+   code for aligned strings, because otherwise some of the branches
+   above cannot reach and have to be transformed to branches around
+   jumps.  The unaligned code is smaller and the branches can reach
+   over it.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+#endif
+.Lunaligned:
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, .Lretdiff	// loop forever (almost anyway)
+#endif
+.Lnextbyte:
+	l8ui	a8, a2, 0
+	l8ui	a9, a3, 0
+	addi	a2, a2, 1
+	bne	a8, a9, .Lretdiff
+	addi	a3, a3, 1
+#if XCHAL_HAVE_LOOPS
+	beqz	a8, .Lretdiff
+#else
+	bnez	a8, .Lnextbyte
+#endif
+.Lretdiff:
+	sub	a2, a8, a9
+	leaf_return
+
+/* s1 is word-aligned; s2 is word-aligned.
+
+   If the zero-overhead loop option is available, use an (almost)
+   infinite zero-overhead loop with conditional exits so we only pay
+   for taken branches when exiting the loop.  */
+
+/* New algorithm, relying on the fact that all normal ASCII is between
+   32 and 127.
+
+   Rather than check all bytes for zero:
+   Take one word (4 bytes).  Call it w1.
+   Shift w1 left by one into w1'.
+   Or w1 and w1'.  For all normal ASCII bit 6 will be 1; for zero it won't.
+   Check that all 4 bit 6's (one for each byte) are one:
+   If they are, we are definitely not done.
+   If they are not, we are probably done, but need to check for zero.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if !XCHAL_HAVE_L32R
+	/* (2 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+.Laligned:
+#if XCHAL_HAVE_L32R
+	l32r	a4, .Lmask0	// mask for byte 0
+	l32r	a7, .Lmask4
+#else
+	const16	a4, MASK0@h
+	const16	a4, MASK0@l
+	const16	a7, MASK4@h
+	const16	a7, MASK4@l
+#endif
+	/* Loop forever */
+1:
+	loop	a0, .Laligned_done
+
+	/* First unrolled loop body.  */
+	l32i	a8, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	slli	a5, a8, 1
+	bne	a8, a9, .Lwne2
+	or	a9, a8, a5
+	bnall	a9, a7, .Lprobeq
+
+	/* Second unrolled loop body.  */
+	l32i	a8, a2, 4	// get word from s1+4
+	l32i	a9, a3, 4	// get word from s2+4
+	slli	a5, a8, 1
+	bne	a8, a9, .Lwne2
+	or	a9, a8, a5
+	bnall	a9, a7, .Lprobeq2
+
+	addi	a2, a2, 8	// advance s1 pointer
+	addi	a3, a3, 8	// advance s2 pointer
+.Laligned_done:
+	j     	1b
+
+.Lprobeq2:
+	/* Adjust pointers to account for the loop unrolling.  */
+	addi	a2, a2, 4
+	addi	a3, a3, 4
+
+#else /* !XCHAL_HAVE_LOOPS */
+
+.Laligned:
+	movi	a4, MASK0	// mask for byte 0
+	movi	a7, MASK4
+	j	.Lfirstword
+.Lnextword:
+	addi	a2, a2, 4	// advance s1 pointer
+	addi	a3, a3, 4	// advance s2 pointer
+.Lfirstword:
+	l32i	a8, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	slli	a5, a8, 1
+	bne	a8, a9, .Lwne2
+	or	a9, a8, a5
+	ball	a9, a7, .Lnextword
+#endif /* !XCHAL_HAVE_LOOPS */
+
+	/* align (0 mod 4) */
+.Lprobeq:
+	/* Words are probably equal, but check for sure.
+	   If not, loop over the rest of string using normal algorithm.  */
+
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+#if XCHAL_HAVE_L32R
+	l32r	a5, .Lmask1	// mask for byte 1
+	l32r	a6, .Lmask2	// mask for byte 2
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	l32r	a7, .Lmask3	// mask for byte 3
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	bnone	a8, a7, .Leq	// if byte 3 is zero
+	/* align (1 mod 4) */
+#else
+	const16	a5, MASK1@h	// mask for byte 1
+	const16	a5, MASK1@l
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	const16	a6, MASK2@h	// mask for byte 2
+	const16	a6, MASK2@l
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	const16	a7, MASK3@h	// mask for byte 3
+	const16	a7, MASK3@l
+	bnone	a8, a7, .Leq	// if byte 3 is zero
+	/* align (2 mod 4) */
+#endif /* XCHAL_HAVE_L32R */
+#if XCHAL_HAVE_DENSITY
+	addi.n	a2, a2, 4	// advance s1 pointer
+	addi.n	a3, a3, 4	// advance s2 pointer
+	/* align (1 mod 4) or (2 mod 4) */
+#else
+	addi	a2, a2, 4	// advance s1 pointer
+	addi	a3, a3, 4	// advance s2 pointer
+	or	a1, a1, a1	// nop
+#if !XCHAL_HAVE_L32R
+	or	a1, a1, a1	// nop
+#endif
+	/* align (2 mod 4) */
+#endif /* XCHAL_HAVE_DENSITY */
+#if XCHAL_HAVE_LOOPS
+1:
+	loop	a0, .Leq	// loop forever (a4 is bigger than max iters)
+	l32i	a8, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	addi	a2, a2, 4	// advance s1 pointer
+	bne	a8, a9, .Lwne
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	bnone	a8, a7, .Leq	// if byte 3 is zero
+	addi	a3, a3, 4	// advance s2 pointer
+	j	1b
+#else /* !XCHAL_HAVE_LOOPS */
+
+	j	.Lfirstword2
+.Lnextword2:
+	addi	a3, a3, 4	// advance s2 pointer
+.Lfirstword2:
+	l32i	a8, a2, 0	// get word from s1
+	l32i	a9, a3, 0	// get word from s2
+	addi	a2, a2, 4	// advance s1 pointer
+	bne	a8, a9, .Lwne
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+	bany	a8, a7, .Lnextword2	// if byte 3 is zero
+#endif /* !XCHAL_HAVE_LOOPS */
+
+	/* Words are equal; some byte is zero.  */
+.Leq:	movi	a2, 0		// return equal
+	leaf_return
+
+.Lwne2:	/* Words are not equal.  On big-endian processors, if none of the
+	   bytes are zero, the return value can be determined by a simple
+	   comparison.  */
+#ifdef __XTENSA_EB__
+	or	a10, a8, a5
+	bnall	a10, a7, .Lsomezero
+	bgeu	a8, a9, .Lposreturn
+	movi	a2, -1
+	leaf_return
+.Lposreturn:
+	movi	a2, 1
+	leaf_return
+.Lsomezero:	// There is probably some zero byte.
+#endif /* __XTENSA_EB__ */
+.Lwne:	/* Words are not equal.  */
+	xor	a2, a8, a9	// get word with nonzero in byte that differs
+	bany	a2, a4, .Ldiff0	// if byte 0 differs
+	movi	a5, MASK1	// mask for byte 1
+	bnone	a8, a4, .Leq	// if byte 0 is zero
+	bany	a2, a5, .Ldiff1	// if byte 1 differs
+	movi	a6, MASK2	// mask for byte 2
+	bnone	a8, a5, .Leq	// if byte 1 is zero
+	bany	a2, a6, .Ldiff2	// if byte 2 differs
+	bnone	a8, a6, .Leq	// if byte 2 is zero
+#ifdef __XTENSA_EB__
+.Ldiff3:
+.Ldiff2:
+.Ldiff1:
+	/* Byte 0 is equal (at least) and there is a difference before a zero
+	   byte.  Just subtract words to get the return value.
+	   The high order equal bytes cancel, leaving room for the sign.  */
+	sub	a2, a8, a9
+	leaf_return
+
+.Ldiff0:
+	/* Need to make room for the sign, so can't subtract whole words.  */
+	extui	a10, a8, 24, 8
+	extui	a11, a9, 24, 8
+	sub	a2, a10, a11
+	leaf_return
+
+#else /* !__XTENSA_EB__ */
+	/* Little-endian is a little more difficult because can't subtract
+	   whole words.  */
+.Ldiff3:
+	/* Bytes 0-2 are equal; byte 3 is different.
+	   For little-endian need to have a sign bit for the difference.  */
+	extui	a10, a8, 24, 8
+	extui	a11, a9, 24, 8
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff0:
+	/* Byte 0 is different.  */
+	extui	a10, a8, 0, 8
+	extui	a11, a9, 0, 8
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff1:
+	/* Byte 0 is equal; byte 1 is different.  */
+	extui	a10, a8, 8, 8
+	extui	a11, a9, 8, 8
+	sub	a2, a10, a11
+	leaf_return
+
+.Ldiff2:
+	/* Bytes 0-1 are equal; byte 2 is different.  */
+	extui	a10, a8, 16, 8
+	extui	a11, a9, 16, 8
+	sub	a2, a10, a11
+	leaf_return
+
+#endif /* !__XTENSA_EB */
+#endif /* FLIX3*/
+#endif /* FLIX3*/
+
+	.size	strcmp, . - strcmp

--- a/newlib/libc/machine/xtensa/strcpy.S
+++ b/newlib/libc/machine/xtensa/strcpy.S
@@ -1,0 +1,235 @@
+/* ANSI C standard library function strcpy.
+
+   Copyright (c) 2001-2008 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+	.text
+	.begin schedule
+	.align	4
+	.literal_position
+	.global	strcpy
+	.type	strcpy, @function
+strcpy:
+	leaf_entry sp, 16
+	/* a2 = dst, a3 = src */
+
+	mov	a10, a2		// leave dst in return value register
+	movi	a4, MASK0
+	movi	a5, MASK1
+	movi	a6, MASK2
+	movi	a7, MASK3
+	bbsi.l	a3, 0, .Lsrc1mod2
+	bbsi.l	a3, 1, .Lsrc2mod4
+.Lsrcaligned:
+
+	/* Check if the destination is aligned.  */
+	movi	a8, 3
+	bnone	a10, a8, .Laligned
+
+	j	.Ldstunaligned
+
+.Lsrc1mod2: // src address is odd
+	l8ui	a8, a3, 0	// get byte 0
+	addi	a3, a3, 1	// advance src pointer
+	s8i	a8, a10, 0	// store byte 0
+	beqz	a8, 1f		// if byte 0 is zero
+	addi	a10, a10, 1	// advance dst pointer
+	bbci.l	a3, 1, .Lsrcaligned // if src is now word-aligned
+
+.Lsrc2mod4: // src address is 2 mod 4
+	l8ui	a8, a3, 0	// get byte 0
+	/* 1-cycle interlock */
+	s8i	a8, a10, 0	// store byte 0
+	beqz	a8, 1f		// if byte 0 is zero
+	l8ui	a8, a3, 1	// get byte 0
+	addi	a3, a3, 2	// advance src pointer
+	s8i	a8, a10, 1	// store byte 0
+	addi	a10, a10, 2	// advance dst pointer
+	bnez	a8, .Lsrcaligned
+1:	leaf_return
+
+
+/* dst is word-aligned; src is word-aligned.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+.Laligned:
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, .Lz3	// loop forever (almost anyway)
+	l32i	a8, a3, 0	// get word from src
+	addi	a3, a3, 4	// advance src pointer
+	bnone	a8, a4, .Lz0	// if byte 0 is zero
+	bnone	a8, a5, .Lz1	// if byte 1 is zero
+	bnone	a8, a6, .Lz2	// if byte 2 is zero
+	s32i	a8, a10, 0	// store word to dst
+	bnone	a8, a7, .Lz3	// if byte 3 is zero
+	addi	a10, a10, 4	// advance dst pointer
+
+#else /* !XCHAL_HAVE_LOOPS */
+
+1:	addi	a10, a10, 4	// advance dst pointer
+.Laligned:
+	l32i	a8, a3, 0	// get word from src
+	addi	a3, a3, 4	// advance src pointer
+	bnone	a8, a4, .Lz0	// if byte 0 is zero
+	bnone	a8, a5, .Lz1	// if byte 1 is zero
+	bnone	a8, a6, .Lz2	// if byte 2 is zero
+	s32i	a8, a10, 0	// store word to dst
+	bany	a8, a7, 1b	// if byte 3 is zero
+#endif /* !XCHAL_HAVE_LOOPS */
+
+.Lz3:	/* Byte 3 is zero.  */
+	leaf_return
+
+.Lz0:	/* Byte 0 is zero.  */
+#ifdef __XTENSA_EB__
+	movi	a8, 0
+#endif
+	s8i	a8, a10, 0
+	leaf_return
+
+.Lz1:	/* Byte 1 is zero.  */
+#ifdef __XTENSA_EB__
+        extui   a8, a8, 16, 16
+#endif
+	s16i	a8, a10, 0
+	leaf_return
+
+.Lz2:	/* Byte 2 is zero.  */
+#ifdef __XTENSA_EB__
+        extui   a8, a8, 16, 16
+#endif
+	s16i	a8, a10, 0
+	movi	a8, 0
+	s8i	a8, a10, 2
+	leaf_return
+
+#if 1
+/* For now just use byte copy loop for the unaligned destination case.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+#endif
+.Ldstunaligned:
+
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, 2f		// loop forever (almost anyway)
+#endif
+1:	l8ui	a8, a3, 0
+	addi	a3, a3, 1
+	s8i	a8, a10, 0
+	addi	a10, a10, 1
+#if XCHAL_HAVE_LOOPS
+	beqz	a8, 2f
+#else
+	bnez	a8, 1b
+#endif
+2:	leaf_return
+
+#else /* 0 */
+
+/* This code is not functional yet.  */
+
+.Ldstunaligned:
+	l32i	a9, a2, 0	// load word from dst
+#ifdef __XTENSA_EB__
+	ssa8b	a9		// rotate by dst alignment so that
+	src	a9, a9, a9	// shift in loop will put back in place
+	ssa8l	a9		// shift left by byte*8
+#else
+	ssa8l	a9		// rotate by dst alignment so that
+	src	a9, a9, a9	// shift in loop will put back in place
+	ssa8b	a9		// shift left by 32-byte*8
+#endif
+
+/* dst is word-aligned; src is unaligned.  */
+
+.Ldstunalignedloop:
+	l32i	a8, a3, 0	// get word from src
+	/* 1-cycle interlock */
+	bnone	a8, a4, .Lu0	// if byte 0 is zero
+	bnone	a8, a5, .Lu1	// if byte 1 is zero
+	bnone	a8, a6, .Lu2	// if byte 2 is zero
+	src	a9, a8, a9	// combine last word and this word
+	s32i	a9, a10, 0	// store word to dst
+	bnone	a8, a7, .Lu3	// if byte 3 is nonzero, iterate
+	l32i	a9, a3, 4	// get word from src
+	addi	a3, a3, 8	// advance src pointer
+	bnone	a9, a4, .Lu4	// if byte 0 is zero
+	bnone	a9, a5, .Lu5	// if byte 1 is zero
+	bnone	a9, a6, .Lu6	// if byte 2 is zero
+	src	a8, a9, a8	// combine last word and this word
+	s32i	a8, a10, 4	// store word to dst
+	addi	a10, a10, 8	// advance dst pointer
+	bany	a8, a7, .Ldstunalignedloop // if byte 3 is nonzero, iterate
+
+	/* Byte 7 is zero.  */
+.Lu7:	leaf_return
+
+.Lu0:	/* Byte 0 is zero.  */
+#ifdef __XTENSA_EB__
+	movi	a8, 0
+#endif
+	s8i	a8, a10, 0
+	leaf_return
+
+.Lu1:	/* Byte 1 is zero.  */
+#ifdef __XTENSA_EB__
+        extui   a8, a8, 16, 16
+#endif
+	s16i	a8, a10, 0
+	leaf_return
+
+.Lu2:	/* Byte 2 is zero.  */
+	s16i	a8, a10, 0
+	movi	a8, 0
+	s8i	a8, a10, 2
+	leaf_return
+
+#endif /* 0 */
+	.end schedule
+
+	.size	strcpy, . - strcpy

--- a/newlib/libc/machine/xtensa/strlen.S
+++ b/newlib/libc/machine/xtensa/strlen.S
@@ -1,0 +1,115 @@
+/* ANSI C standard library function strlen.
+
+   Copyright (c) 2001-2008 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+	.text
+	.begin schedule
+	.align	4
+	.literal_position
+	.global	strlen
+	.type	strlen, @function
+strlen:
+	leaf_entry sp, 16
+	/* a2 = s */
+
+	addi	a3, a2, -4	// because we overincrement at the end
+	movi	a4, MASK0
+	movi	a5, MASK1
+	movi	a6, MASK2
+	movi	a7, MASK3
+	bbsi.l	a2, 0, .L1mod2
+	bbsi.l	a2, 1, .L2mod4
+	j	.Laligned
+
+.L1mod2: // address is odd
+	l8ui	a8, a3, 4	// get byte 0
+	addi	a3, a3, 1	// advance string pointer
+	beqz	a8, .Lz3	// if byte 0 is zero
+	bbci.l	a3, 1, .Laligned // if string pointer is now word-aligned
+
+.L2mod4: // address is 2 mod 4
+	addi	a3, a3, 2	// advance ptr for aligned access
+	l32i	a8, a3, 0	// get word with first two bytes of string
+	bnone	a8, a6, .Lz2	// if byte 2 (of word, not string) is zero
+	bany	a8, a7, .Laligned // if byte 3 (of word, not string) is nonzero
+
+	/* Byte 3 is zero.  */
+	addi	a3, a3, 3	// point to zero byte
+	sub	a2, a3, a2	// subtract to get length
+	leaf_return
+
+
+/* String is word-aligned.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+#endif
+.Laligned:
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, .Lz3	// loop forever (almost anyway)
+#endif
+1:	l32i	a8, a3, 4	// get next word of string
+	addi	a3, a3, 4	// advance string pointer
+	bnone	a8, a4, .Lz0	// if byte 0 is zero
+	bnone	a8, a5, .Lz1	// if byte 1 is zero
+	bnone	a8, a6, .Lz2	// if byte 2 is zero
+#if XCHAL_HAVE_LOOPS
+	bnone	a8, a7, .Lz3	// if byte 3 is zero
+#else
+	bany	a8, a7, 1b	// repeat if byte 3 is non-zero
+#endif
+
+.Lz3:	/* Byte 3 is zero.  */
+	addi	a3, a3, 3	// point to zero byte
+	/* Fall through....  */
+
+.Lz0:	/* Byte 0 is zero.  */
+	sub	a2, a3, a2	// subtract to get length
+	leaf_return
+
+.Lz1:	/* Byte 1 is zero.  */
+	addi	a3, a3, 1	// point to zero byte
+	sub	a2, a3, a2	// subtract to get length
+	leaf_return
+
+.Lz2:	/* Byte 2 is zero.  */
+	addi	a3, a3, 2	// point to zero byte
+	sub	a2, a3, a2	// subtract to get length
+	leaf_return
+
+	.end schedule
+
+	.size	strlen, . - strlen

--- a/newlib/libc/machine/xtensa/strncpy.S
+++ b/newlib/libc/machine/xtensa/strncpy.S
@@ -1,0 +1,258 @@
+/* ANSI C standard library function strncpy.
+
+   Copyright (c) 2001-2008 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include "xtensa-asm.h"
+
+	.text
+.begin schedule
+	.align	4
+	.literal_position
+__strncpy_aux:
+
+.Lsrc1mod2: // src address is odd
+	l8ui	a8, a3, 0	// get byte 0
+	addi	a3, a3, 1	// advance src pointer
+	s8i	a8, a10, 0	// store byte 0
+	addi	a4, a4, -1	// decrement n
+	beqz    a4, .Lret       // if n is zero
+	addi	a10, a10, 1	// advance dst pointer
+	beqz	a8, .Lfill	// if byte 0 is zero
+	bbci.l	a3, 1, .Lsrcaligned // if src is now word-aligned
+
+.Lsrc2mod4: // src address is 2 mod 4
+	l8ui	a8, a3, 0	// get byte 0
+	addi	a4, a4, -1	// decrement n
+	s8i	a8, a10, 0	// store byte 0
+	beqz    a4, .Lret       // if n is zero
+	addi	a10, a10, 1	// advance dst pointer
+	beqz	a8, .Lfill	// if byte 0 is zero
+	l8ui	a8, a3, 1	// get byte 0
+	addi	a3, a3, 2	// advance src pointer
+	s8i	a8, a10, 0	// store byte 0
+	addi	a4, a4, -1	// decrement n
+	beqz    a4, .Lret       // if n is zero
+	addi	a10, a10, 1	// advance dst pointer
+	bnez	a8, .Lsrcaligned
+	j	.Lfill
+
+.Lret:
+	leaf_return
+
+
+	.align	4
+	.global	strncpy
+	.type	strncpy, @function
+strncpy:
+	leaf_entry sp, 16
+	/* a2 = dst, a3 = src */
+
+	mov	a10, a2		// leave dst in return value register
+	beqz    a4, .Lret       // if n is zero
+
+	movi	a11, MASK0
+	movi	a5, MASK1
+	movi	a6, MASK2
+	movi	a7, MASK3
+	bbsi.l	a3, 0, .Lsrc1mod2
+	bbsi.l	a3, 1, .Lsrc2mod4
+.Lsrcaligned:
+
+	/* Check if the destination is aligned.  */
+	movi	a8, 3
+	bnone	a10, a8, .Laligned
+
+	j	.Ldstunaligned
+
+
+/* Fill the dst with zeros -- n is at least 1.  */
+
+.Lfill:
+	movi	a9, 0
+	bbsi.l	a10, 0, .Lfill1mod2
+	bbsi.l	a10, 1, .Lfill2mod4
+.Lfillaligned:
+	blti	a4, 4, .Lfillcleanup
+
+	/* Loop filling complete words with zero.  */
+#if XCHAL_HAVE_LOOPS
+
+	srai	a8, a4, 2
+	loop	a8, 1f
+	s32i	a9, a10, 0
+	addi	a10, a10, 4
+
+1:	slli	a8, a8, 2
+	sub	a4, a4, a8
+
+#else /* !XCHAL_HAVE_LOOPS */
+
+1:	s32i	a9, a10, 0
+	addi	a10, a10, 4
+	addi	a4, a4, -4
+	bgei    a4, 4, 1b
+
+#endif /* !XCHAL_HAVE_LOOPS */
+
+	beqz	a4, 2f
+
+.Lfillcleanup:
+	/* Fill leftover (1 to 3) bytes with zero.  */
+	s8i	a9, a10, 0	// store byte 0
+	addi	a4, a4, -1	// decrement n
+	addi	a10, a10, 1
+	bnez    a4, .Lfillcleanup
+
+2:	leaf_return
+
+.Lfill1mod2: // dst address is odd
+	s8i	a9, a10, 0	// store byte 0
+	addi	a4, a4, -1	// decrement n
+	beqz    a4, 2b		// if n is zero
+	addi    a10, a10, 1	// advance dst pointer
+	bbci.l	a10, 1, .Lfillaligned // if dst is now word-aligned
+
+.Lfill2mod4: // dst address is 2 mod 4
+	s8i	a9, a10, 0	// store byte 0
+	addi	a4, a4, -1	// decrement n
+	beqz    a4, 2b		// if n is zero
+	s8i	a9, a10, 1	// store byte 1
+	addi	a4, a4, -1	// decrement n
+	beqz    a4, 2b		// if n is zero
+	addi    a10, a10, 2	// advance dst pointer
+	j	.Lfillaligned
+
+
+/* dst is word-aligned; src is word-aligned; n is at least 1.  */
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+#endif
+.Laligned:
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, 1f		// loop forever (almost anyway)
+	blti	a4, 5, .Ldstunaligned // n is near limit; do one at a time
+	l32i	a8, a3, 0	// get word from src
+	addi	a3, a3, 4	// advance src pointer
+	bnone	a8, a11, .Lz0	// if byte 0 is zero
+	bnone	a8, a5, .Lz1	// if byte 1 is zero
+	bnone	a8, a6, .Lz2	// if byte 2 is zero
+	s32i	a8, a10, 0	// store word to dst
+	addi	a4, a4, -4	// decrement n
+	addi	a10, a10, 4	// advance dst pointer
+	bnone	a8, a7, .Lfill	// if byte 3 is zero
+1:
+
+#else /* !XCHAL_HAVE_LOOPS */
+
+1:	blti	a4, 5, .Ldstunaligned // n is near limit; do one at a time
+	l32i	a8, a3, 0	// get word from src
+	addi	a3, a3, 4	// advance src pointer
+	bnone	a8, a11, .Lz0	// if byte 0 is zero
+	bnone	a8, a5, .Lz1	// if byte 1 is zero
+	bnone	a8, a6, .Lz2	// if byte 2 is zero
+	s32i	a8, a10, 0	// store word to dst
+	addi	a4, a4, -4	// decrement n
+	addi	a10, a10, 4	// advance dst pointer
+	bany	a8, a7, 1b	// no zeroes
+#endif /* !XCHAL_HAVE_LOOPS */
+
+	j	.Lfill
+
+.Lz0:	/* Byte 0 is zero.  */
+#ifdef __XTENSA_EB__
+	movi	a8, 0
+#endif
+	s8i	a8, a10, 0
+	addi	a4, a4, -1	// decrement n
+	addi	a10, a10, 1	// advance dst pointer
+	j	.Lfill
+
+.Lz1:	/* Byte 1 is zero.  */
+#ifdef __XTENSA_EB__
+        extui   a8, a8, 16, 16
+#endif
+	s16i	a8, a10, 0
+	addi	a4, a4, -2	// decrement n
+	addi	a10, a10, 2	// advance dst pointer
+	j	.Lfill
+
+.Lz2:	/* Byte 2 is zero.  */
+#ifdef __XTENSA_EB__
+        extui   a8, a8, 16, 16
+#endif
+	s16i	a8, a10, 0
+	movi	a8, 0
+	s8i	a8, a10, 2
+	addi	a4, a4, -3	// decrement n
+	addi	a10, a10, 3	// advance dst pointer
+	j	.Lfill
+
+	.align	4
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	/* (2 mod 4) alignment for loop instruction */
+#else
+	/* (1 mod 4) alignment for loop instruction */
+	.byte	0
+	.byte	0
+#endif
+#endif
+.Ldstunaligned:
+
+#if XCHAL_HAVE_LOOPS
+#if XCHAL_HAVE_DENSITY
+	_movi.n	a8, 0		// set up for the maximum loop count
+#else
+	_movi	a8, 0		// set up for the maximum loop count
+#endif
+	loop	a8, 2f		// loop forever (almost anyway)
+#endif
+1:	l8ui	a8, a3, 0
+	addi	a3, a3, 1
+	s8i	a8, a10, 0
+	addi	a4, a4, -1
+	beqz	a4, 3f
+	addi	a10, a10, 1
+#if XCHAL_HAVE_LOOPS
+	beqz	a8, 2f
+#else
+	bnez	a8, 1b
+#endif
+2:	j	.Lfill
+
+3:	leaf_return
+.end schedule
+
+	.size	strncpy, . - strncpy

--- a/newlib/libc/machine/xtensa/xtensa-asm.h
+++ b/newlib/libc/machine/xtensa/xtensa-asm.h
@@ -1,0 +1,72 @@
+/* Copyright (c) 2006 Tensilica Inc.
+
+   Permission is hereby granted, free of charge, to any person obtaining
+   a copy of this software and associated documentation files (the
+   "Software"), to deal in the Software without restriction, including
+   without limitation the rights to use, copy, modify, merge, publish,
+   distribute, sublicense, and/or sell copies of the Software, and to
+   permit persons to whom the Software is furnished to do so, subject to
+   the following conditions:
+
+   The above copyright notice and this permission notice shall be included
+   in all copies or substantial portions of the Software.
+
+   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+   EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+   IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+   CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+   TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+   SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.  */
+
+#include <machine/core-isa.h>
+
+# Define macros for leaf function entry and return, supporting either the
+# standard register windowed ABI or the non-windowed call0 ABI.  These
+# macros do not allocate any extra stack space, so they only work for
+# leaf functions that do not need to spill anything to the stack.
+
+	.macro leaf_entry reg, size
+#if XCHAL_HAVE_WINDOWED && !__XTENSA_CALL0_ABI__
+	entry \reg, \size
+#else
+	/* do nothing */
+#endif
+	.endm
+
+	.macro leaf_return
+#if XCHAL_HAVE_WINDOWED && !__XTENSA_CALL0_ABI__
+	retw
+#else
+	ret
+#endif
+	.endm
+
+	.macro	src_b	r, w0, w1
+#ifdef __XTENSA_EB__
+	src	\r, \w0, \w1
+#else
+	src	\r, \w1, \w0
+#endif
+	.endm
+
+	.macro	ssa8	r
+#ifdef __XTENSA_EB__
+	ssa8b	\r
+#else
+	ssa8l	\r
+#endif
+	.endm
+
+#if XCHAL_HAVE_BE
+#define	MASK0 0xff000000
+#define	MASK1 0x00ff0000
+#define	MASK2 0x0000ff00
+#define	MASK3 0x000000ff
+#else
+#define	MASK0 0x000000ff
+#define	MASK1 0x0000ff00
+#define	MASK2 0x00ff0000
+#define	MASK3 0xff000000
+#endif
+

--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -99,6 +99,7 @@ machine_dirs = {
 		 'x86_64': 'x86_64',
 		 'xc16x': 'xc16x',
 		 'xstormy16': 'xstormy16',
+		 'xtensa': 'xtensa',
 		 'z8k': 'z8k',
 		 'spu': 'spu',
 	       }

--- a/newlib/libm/machine/xtensa/feclearexcept.c
+++ b/newlib/libm/machine/xtensa/feclearexcept.c
@@ -1,0 +1,46 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int feclearexcept(int except)
+{
+  unsigned int fsr;
+
+  if (except & ~FE_ALL_EXCEPT)
+    return -1;
+  except <<= _FE_EXCEPTION_FLAGS_OFFSET;
+  asm ("rur.fsr %0" : "=a"(fsr));
+  fsr = fsr & ~except;
+  asm ("wur.fsr %0" : : "a"(fsr));
+  return 0;
+}
+#endif

--- a/newlib/libm/machine/xtensa/fegetenv.c
+++ b/newlib/libm/machine/xtensa/fegetenv.c
@@ -1,0 +1,56 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int fegetenv(fenv_t * env_ptr)
+{
+  unsigned int fsr;
+  unsigned int fcr;
+  asm ("rur.fsr %0" : "=a"(fsr));
+  asm ("rur.fcr %0" : "=a"(fcr));
+  *env_ptr = fsr | fcr;
+  return 0;
+}
+
+
+int fesetenv(const fenv_t * env_ptr)
+{
+  fenv_t env = *env_ptr;
+  if (env & ~(_FE_FLOATING_ENV_MASK))
+    return -1;
+  asm ("wur.fsr %0" : : "a"(*env_ptr));
+  asm ("wur.fcr %0" : : "a"(*env_ptr));
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/fegetexcept.c
+++ b/newlib/libm/machine/xtensa/fegetexcept.c
@@ -1,0 +1,67 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+/* These functions are glibc extensions.  */
+
+#include <fenv.h>
+
+int fegetexcept(void)
+{
+  fexcept_t current;
+  asm ("rur.fsr %0" : "=a"(current));
+  return (current >> _FE_EXCEPTION_ENABLE_OFFSET) & FE_ALL_EXCEPT;
+}
+
+
+int feenableexcept(int excepts)
+{
+  fexcept_t current;
+  if (excepts & ~FE_ALL_EXCEPT)
+    return -1;
+  asm ("rur.fcr %0" : "=a"(current));
+  current |= excepts << _FE_EXCEPTION_ENABLE_OFFSET;
+  asm ("wur.fcr %0" : "=a"(current));
+  return 0;
+}
+
+
+int fedisableexcept(int excepts)
+{
+  fexcept_t current;
+  if (excepts & ~FE_ALL_EXCEPT)
+    return -1;
+  asm ("rur.fcr %0" : "=a"(current));
+  current &= ~(excepts << _FE_EXCEPTION_ENABLE_OFFSET);
+  asm ("wur.fcr %0" : "=a"(current));
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/fegetexceptflag.c
+++ b/newlib/libm/machine/xtensa/fegetexceptflag.c
@@ -1,0 +1,63 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int fegetexceptflag(fexcept_t *flagp, int excepts)
+{
+  unsigned int fsr;
+  if (excepts & ~FE_ALL_EXCEPT)
+    return -1;
+  asm ("rur.fsr %0" : "=a"(fsr));
+  fsr >>= _FE_EXCEPTION_FLAGS_OFFSET;
+  excepts &= fsr;
+  *flagp = excepts;
+
+  return 0;
+}
+
+int fesetexceptflag(const fexcept_t *flagp, int excepts)
+{
+  if (excepts & ~FE_ALL_EXCEPT)
+    return -1;
+
+  unsigned int fsr;
+
+  asm ("rur.fsr %0" : "=a"(fsr));
+
+  fsr &= ~(excepts << _FE_EXCEPTION_FLAGS_OFFSET);
+  fsr |= ((*flagp & excepts) << _FE_EXCEPTION_FLAGS_OFFSET);
+  asm ("wur.fsr %0" : : "a"(fsr));
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/fegetround.c
+++ b/newlib/libm/machine/xtensa/fegetround.c
@@ -1,0 +1,50 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int fegetround(void)
+{
+  fexcept_t current;
+  asm ("rur.fcr %0" : "=a"(current));
+  return (current & _FE_ROUND_MODE_MASK) >> _FE_ROUND_MODE_OFFSET;
+}
+
+
+int fesetround(int round)
+{
+  if (round & ~_FE_ROUND_MODE_MASK)
+    return -1;
+  asm ("wur.fcr %0" : : "a"(round));
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/feholdexcept.c
+++ b/newlib/libm/machine/xtensa/feholdexcept.c
@@ -1,0 +1,55 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int feholdexcept(fenv_t * envp)
+{
+  fexcept_t fsr;
+  fenv_t fcr;
+  /* Get the environment.  */
+  asm ("rur.fcr %0" : "=a"(fcr));
+  asm ("rur.fsr %0" : "=a"(fsr));
+  *envp = fsr | fcr;
+
+  /* Clear the exception enable flags.  */
+  fcr &= _FE_ROUND_MODE_MASK;
+  asm ("wur.fcr %0" : :"a"(fcr));
+
+  /* Clear the exception happened flags.  */
+  fsr = 0;
+  asm ("wur.fsr %0" : :"a"(fsr));
+
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/feraiseexcept.c
+++ b/newlib/libm/machine/xtensa/feraiseexcept.c
@@ -1,0 +1,50 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+/* Xtensa doesn't trap, so setting the flags is the best we can
+   do.  */
+
+#include <fenv.h>
+
+int feraiseexcept(int excepts)
+{
+  fexcept_t current;
+
+  if (excepts & ~FE_ALL_EXCEPT)
+    return -1;
+  asm ("rur.fsr %0" : "=a"(current));
+  current |= excepts << _FE_EXCEPTION_FLAGS_OFFSET;
+  asm ("wur.fsr %0" : : "a"(current));
+  return 0;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/fetestexcept.c
+++ b/newlib/libm/machine/xtensa/fetestexcept.c
@@ -1,0 +1,41 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+
+#include <fenv.h>
+
+int fetestexcept(int excepts)
+{
+  fexcept_t current;
+  asm ("rur.fsr %0" : "=a"(current));
+  return (current >> _FE_EXCEPTION_FLAGS_OFFSET) & excepts;
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/feupdateenv.c
+++ b/newlib/libm/machine/xtensa/feupdateenv.c
@@ -1,0 +1,45 @@
+/* Copyright (c) 2011 Tensilica Inc.  ALL RIGHTS RESERVED.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. Redistributions in binary form must reproduce the above
+      copyright notice, this list of conditions and the following
+      disclaimer in the documentation and/or other materials provided
+      with the distribution.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+   "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+   LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+   FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL
+   TENSILICA INCORPORATED BE LIABLE FOR ANY DIRECT, INDIRECT,
+   INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+   (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+   SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+   HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+   STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+   OF THE POSSIBILITY OF SUCH DAMAGE.  */
+
+#include <machine/core-isa.h>
+
+#if XCHAL_HAVE_FP || XCHAL_HAVE_DFP
+#include <fenv.h>
+
+int feupdateenv(const fenv_t * envp)
+{
+  fenv_t current;
+  int err = fegetenv (&current);
+  if (err != 0)
+    return err;
+  err = fesetenv (envp);
+  if (err != 0)
+    return err;
+  return feraiseexcept (current);
+}
+
+#endif

--- a/newlib/libm/machine/xtensa/meson.build
+++ b/newlib/libm/machine/xtensa/meson.build
@@ -1,7 +1,7 @@
 #
 # SPDX-License-Identifier: BSD-3-Clause
 #
-# Copyright © 2019 Keith Packard
+# Copyright © 2019 Jonathan McDowell
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -32,73 +32,27 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 # OF THE POSSIBILITY OF SUCH DAMAGE.
 #
-libm_machine_dirs = {
-		      'aarch64' : 'aarch64',
-		      'arm' : 'arm',
-		      'i386' : 'i386',
-		      'i486' : 'i386',
-		      'i586' : 'i386',
-		      'i686' : 'i386',
-		      'nds32' : 'nds32',
-		      'riscv' : 'riscv',
-		      'riscv64' : 'riscv',
-		      'spu' : 'spu',
-		      'xtensa': 'xtensa',
-		    }
 
-libdirs = ['math', 'common', 'complex']
-
-libnames = libdirs
-
-need_generic_fenv = true
-
-if libm_machine_dirs.has_key(host_cpu)
-  libm_machine_dir = join_paths('machine', libm_machine_dirs[host_cpu])
-  libdirs = [libm_machine_dir] + libdirs
-  libnames = ['machine'] + libnames
-  if run_command('test', '-f', join_paths(libm_machine_dir, 'fegetenv.c')).returncode() == 0
-    need_generic_fenv = false
-  endif
-else
-  warning('No libm machine directory for cpu ' + host_cpu)
-endif
-
-if need_generic_fenv
-  libdirs = ['fenv'] + libdirs
-  libnames = ['fenv'] + libnames
-endif
-
-math_inc = [include_directories('common'), inc]
-
-foreach libdir : libdirs
-  subdir(libdir)
-endforeach
+srcs_libm_machine = [
+  'feclearexcept.c',
+  'fegetenv.c',
+  'fegetexcept.c',
+  'fegetexceptflag.c',
+  'fegetround.c',
+  'feholdexcept.c',
+  'feraiseexcept.c',
+  'fetestexcept.c',
+  'feupdateenv.c',
+]
 
 foreach target : targets
-  value = get_variable('target_' + target)
-  libobjs = []
-
-  foreach libname : libnames
-    libobjs += get_variable('lib_' + libname + target).extract_all_objects(recursive:true)
-  endforeach
-
-  instdir = join_paths(get_option('libdir'), value[0])
-
-  if target == ''
-    libm_name = 'm'
-  else
-    libm_name = join_paths(target, 'libm')
-  endif
-
-  set_variable('lib_m' + target,
-	       static_library(libm_name,
-			      install : true,
-			      install_dir : instdir,
-			      pic: false,
-			      objects : libobjs))
+	value = get_variable('target_' + target)
+	set_variable('lib_machine' + target,
+		static_library('machine' + target,
+			srcs_libm_machine,
+			pic: false,
+			include_directories: [ inc,
+					       include_directories('../../common'),
+					       include_directories('../../../libc/machine/xtensa') ],
+			c_args: value[1] + ['-fno-builtin']))
 endforeach
-
-if enable_tests
-  subdir('test')
-endif
-


### PR DESCRIPTION
This takes the work by Max Filippov for newlib, which is in turn based on Tensilica's work, and tries to import the minimal amount needed to get picolibc working. Tested on a ESP8266 with the 2.2.1 + 3.0.1 Espressif NONOS SDKs + GCC 9.2.1 from Debian.

The only issue I haven't worked out how to cleanly handle is that the standard SDK treats uint32_t as int, but stdint.h will default to it being long for the lx106/ESP8266 - the vendor supplied file has a hack to force uint32_t to int for TENSILICA but that doesn't seem clean.

I have a patch to build a picolibc that's useful for the Debian gcc-xtensa-lx106 packages as well, which I'll file separately.