### PR TITLE
debian: Enable package for xtensa-lx106 (ESP8266)

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: picolibc
 Priority: optional
 Maintainer: Keith Packard <keithp@keithp.com>
-Build-Depends: debhelper-compat (= 12), gcc-arm-none-eabi, gcc-riscv64-unknown-elf, meson, ninja-build
+Build-Depends: debhelper-compat (= 12), gcc-arm-none-eabi, gcc-riscv64-unknown-elf, gcc-xtensa-lx106, meson, ninja-build
 Standards-Version: 4.4.1
 Section: devel
 HomePage: https://keithp.com/git/picolibc
@@ -23,3 +23,11 @@ Description: Smaller embedded C library for ARM development
  PicoLibc is a combination of Newlib and AVR libc bits designed
  for small-RAM embedded systems. This package has binaries for
  ARM processors. This library is intended to replace libnewlib-nano
+
+Package: picolibc-xtensa-lx106-elf
+Architecture: all
+Depends: ${misc:Depends}, gcc-xtensa-lx106
+Description: Smaller embedded C library for ESP8266 development
+ PicoLibc is a combination of Newlib and AVR libc bits designed
+ for small-RAM embedded systems. This package has binaries for
+ ESP8266 processors.

--- a/debian/picolibc-xtensa-lx106-elf.install
+++ b/debian/picolibc-xtensa-lx106-elf.install
@@ -1,0 +1,1 @@
+usr/lib/xtensa-lx106-elf

--- a/debian/picolibc-xtensa-lx106-elf.lintian-overrides
+++ b/debian/picolibc-xtensa-lx106-elf.lintian-overrides
@@ -1,0 +1,3 @@
+picolibc-xtensa-lx106-elf: arch-independent-package-contains-binary-or-object usr/lib/*
+picolibc-xtensa-lx106-elf: unstripped-static-library usr/lib/*
+picolibc-xtensa-lx106-elf: static-library-has-unneeded-section usr/lib/*

--- a/debian/picolibc-xtensa-lx106-elf.triggers
+++ b/debian/picolibc-xtensa-lx106-elf.triggers
@@ -1,0 +1,1 @@
+interest-noawait /usr/lib/gcc/xtensa-lx106-elf

--- a/debian/rules
+++ b/debian/rules
@@ -20,6 +20,7 @@ BUILDDIR=build
 
 RISCV_ARCH=riscv64-unknown-elf
 ARM_ARCH=arm-none-eabi
+LX106_ARCH=xtensa-lx106-elf
 
 MESON_SHARED_FLAGS = \
 	--prefix=/usr
@@ -38,6 +39,14 @@ MESON_ARM_FLAGS = \
 	-Dincludedir=lib/picolibc/$(ARM_ARCH)/include \
 	-Dlibdir=lib/picolibc/$(ARM_ARCH)/lib
 
+MESON_LX106_FLAGS = \
+	$(MESON_SHARED_FLAGS) \
+	--cross-file cross-$(LX106_ARCH).txt \
+	-Dnewlib-long-time_t=true \
+	-Dspecsdir=/usr/lib/gcc/$(LX106_ARCH) \
+	-Dincludedir=lib/$(LX106_ARCH)/include \
+	-Dlibdir=lib/$(LX106_ARCH)/lib
+
 override_dh_autoreconf:
 	echo 'no reconf needed'
 
@@ -47,10 +56,12 @@ override_dh_auto_clean:
 override_dh_auto_configure:
 	meson . debian/$(BUILDDIR)/$(RISCV_ARCH) $(MESON_RISCV_FLAGS)
 	meson . debian/$(BUILDDIR)/$(ARM_ARCH) $(MESON_ARM_FLAGS)
+	meson . debian/$(BUILDDIR)/$(LX106_ARCH) $(MESON_LX106_FLAGS)
 
 override_dh_auto_build:
 	cd debian/$(BUILDDIR)/$(RISCV_ARCH) && ninja
 	cd debian/$(BUILDDIR)/$(ARM_ARCH) && ninja
+	cd debian/$(BUILDDIR)/$(LX106_ARCH) && ninja
 
 override_dh_auto_test:
 ifeq (,$(filter nocheck,$(DEB_BUILD_OPTIONS)))
@@ -61,3 +72,4 @@ endif
 override_dh_auto_install:
 	cd debian/$(BUILDDIR)/$(RISCV_ARCH) && DESTDIR=${CURDIR}/debian/tmp ninja install
 	cd debian/$(BUILDDIR)/$(ARM_ARCH) && DESTDIR=${CURDIR}/debian/tmp ninja install
+	cd debian/$(BUILDDIR)/$(LX106_ARCH) && DESTDIR=${CURDIR}/debian/tmp ninja install


### PR DESCRIPTION
Build the lx106 library. Unlike the existing arm/riscv variants we install this directly into the configured gcc paths; there is no alternative libc in Debian for this platform so this should be the default.

(obviously needs lx106 support merged in, but I've confirmed doing that from master and throwing the tree at sbuild works as expected.)