### PR TITLE
Fix undefined bzero function in explicit_bzero

### DIFF
--- a/newlib/libc/string/explicit_bzero.c
+++ b/newlib/libc/string/explicit_bzero.c
@@ -6,6 +6,8 @@
 
 #include <string.h>
 
+void bzero(void *, size_t);
+
 /*
  * explicit_bzero - don't let the compiler optimize away bzero
  */


### PR DESCRIPTION
With `-Wimplicit-function-declaration` (enabled by `-Wall`) and with `_POSIX_C_SOURCE` set to 200809, the `bzero` declaration is hidden. Therefore, declare it in the source file to avoid this warning.

Note: I'm not using any build system. I'm trying to use picolibc in TinyGo, where it is much more convenient to build the libc by the compiler (TinyGo) when needed without any toolchain or build system dependencies. I've set `_POSIX_C_SOURCE` to 200809L otherwise string/strcasecmp_l.c doesn't compile:

```
/home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/newlib/libc/string/strcasecmp_l.c:48:22: error: implicit declaration of function 'tolower_l' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
      const int c1 = tolower_l (*s1++, locale);
                     ^
```