### PR TITLE
Define _POSIX_C_SOURCE=200809L for symbols in that standard

### DIFF
--- a/newlib/libc/string/strcasecmp_l.c
+++ b/newlib/libc/string/strcasecmp_l.c
@@ -36,6 +36,8 @@ QUICKREF
 	strcasecmp_l
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <strings.h>
 #include <ctype.h>
 

--- a/newlib/libc/string/strcoll_l.c
+++ b/newlib/libc/string/strcoll_l.c
@@ -37,6 +37,8 @@ QUICKREF
 	strcoll_l ansi pure
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <string.h>
 
 int

--- a/newlib/libc/string/strerror.c
+++ b/newlib/libc/string/strerror.c
@@ -381,6 +381,8 @@ QUICKREF
 	strerror ansi pure
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <errno.h>
 #include <string.h>
 

--- a/newlib/libc/string/strncasecmp_l.c
+++ b/newlib/libc/string/strncasecmp_l.c
@@ -37,6 +37,8 @@ QUICKREF
 	strncasecmp_l
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <strings.h>
 #include <ctype.h>
 

--- a/newlib/libc/string/strxfrm_l.c
+++ b/newlib/libc/string/strxfrm_l.c
@@ -46,6 +46,8 @@ QUICKREF
 	strxfrm_l ansi pure
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <string.h>
 
 size_t

--- a/newlib/libc/string/wcscasecmp_l.c
+++ b/newlib/libc/string/wcscasecmp_l.c
@@ -36,6 +36,8 @@ QUICKREF
 	wcscasecmp_l 
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <wchar.h>
 #include <wctype.h>
 

--- a/newlib/libc/string/wcscoll_l.c
+++ b/newlib/libc/string/wcscoll_l.c
@@ -33,6 +33,8 @@ PORTABILITY
 <<wcscoll_l>> is POSIX-1.2008.
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <_ansi.h>
 #include <wchar.h>
 

--- a/newlib/libc/string/wcsncasecmp_l.c
+++ b/newlib/libc/string/wcsncasecmp_l.c
@@ -37,6 +37,8 @@ QUICKREF
 	wcsncasecmp_l
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <wchar.h>
 #include <wctype.h>
 

--- a/newlib/libc/string/wcsxfrm_l.c
+++ b/newlib/libc/string/wcsxfrm_l.c
@@ -36,6 +36,8 @@ PORTABILITY
 <<wcsxfrm_l>> is POSIX-1.2008.
 */
 
+#define _POSIX_C_SOURCE 200809L
+
 #include <_ansi.h>
 #include <wchar.h>
 


### PR DESCRIPTION
This patch is required to get picolibc to compile with `-Wall -Werror -std=c99`, otherwise it will complain about implicit function declarations and similar:

```
picolibc/newlib/libc/string/strcasecmp_l.c:48:22: error: implicit declaration of function 'tolower_l' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
picolibc/newlib/libc/string/strcoll_l.c:43:49: error: declaration of 'struct __locale_t' will not be visible outside of this function [-Werror,-Wvisibility]
```

Note: you might see this as an alternative to #24.