### PR TITLE
Meson and CPU family

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -95,7 +95,7 @@ posix_console = posix_io and get_option('posix-console')
 sysroot_install = get_option('sysroot-install')
 newlib_obsolete_math = get_option('newlib-obsolete-math')
 
-host_cpu=host_machine.cpu()
+host_cpu=host_machine.cpu_family()
 if host_cpu == ''
   host_cmds = meson.get_compiler('c').cmd_array() + ['-dumpmachine']
   host_cc_machine=run_command(host_cmds).stdout().strip().split('-')
@@ -314,7 +314,7 @@ if has_semihost
   # If we're using semihosting, we assume that there's a
   # custom linker script that includes picolibc.specs
 
-  test_link_name = 'test-' + host_machine.cpu() + '.ld'
+  test_link_name = 'test-' + host_machine.cpu_family() + '.ld'
   test_link_dep = files(test_link_name)
 
   # Linker args must be strings (seems like a bug), so compute the

--- a/meson.build
+++ b/meson.build
@@ -314,7 +314,7 @@ if has_semihost
   # If we're using semihosting, we assume that there's a
   # custom linker script that includes picolibc.specs
 
-  test_link_name = 'test-' + host_machine.cpu_family() + '.ld'
+  test_link_name = 'test-' + host_cpu_family + '.ld'
   test_link_dep = files(test_link_name)
 
   # Linker args must be strings (seems like a bug), so compute the

--- a/meson.build
+++ b/meson.build
@@ -95,12 +95,12 @@ posix_console = posix_io and get_option('posix-console')
 sysroot_install = get_option('sysroot-install')
 newlib_obsolete_math = get_option('newlib-obsolete-math')
 
-host_cpu=host_machine.cpu_family()
-if host_cpu == ''
+host_cpu_family=host_machine.cpu_family()
+if host_cpu_family == ''
   host_cmds = meson.get_compiler('c').cmd_array() + ['-dumpmachine']
   host_cc_machine=run_command(host_cmds).stdout().strip().split('-')
-  host_cpu=host_cc_machine[0]
-  message('Computed host_cpu as ' + host_cpu)
+  host_cpu_family=host_cc_machine[0]
+  message('Computed host_cpu_family as ' + host_cpu_family)
 endif
 
 specs_dir = get_option('specsdir')

--- a/newlib/libc/meson.build
+++ b/newlib/libc/meson.build
@@ -126,8 +126,8 @@ libnames = libdirs
 
 need_generic_fenv_h = true
 
-if machine_dirs.has_key(host_cpu)
-  machine_dir = join_paths('machine', machine_dirs[host_cpu])
+if machine_dirs.has_key(host_cpu_family)
+  machine_dir = join_paths('machine', machine_dirs[host_cpu_family])
   fenv_file_check = join_paths(machine_dir, 'sys', 'fenv.h')
   if run_command('test', '-f', fenv_file_check).returncode() == 0
     need_generic_fenv_h = false
@@ -146,7 +146,7 @@ if machine_dirs.has_key(host_cpu)
   libdirs = [machine_dir] + libdirs
   libnames = ['machine'] + libnames
 else
-  warning('No libc machine directory for cpu ' + host_cpu)
+  warning('No libc machine directory for CPU family ' + host_cpu_family)
   need_generic_fenv_h = true
 endif
 

--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -74,7 +74,7 @@ void _start(void);
 extern uint8_t __stack[];
 
 #define i(addr,name)	[(addr)/4] = arm_ ## name ## _isr
-
+/*
 __section(".data.init.enter")
 const void *__weak_interrupt_vector[] __attribute((aligned(128))) = {
 	[0] = __stack,
@@ -87,3 +87,4 @@ const void *__weak_interrupt_vector[] __attribute((aligned(128))) = {
 	i(0x3c, systick),
 };
 __weak_reference(__weak_interrupt_vector, __interrupt_vector);
+*/

--- a/newlib/libc/picolib/machine/arm/interrupt.c
+++ b/newlib/libc/picolib/machine/arm/interrupt.c
@@ -53,12 +53,10 @@ void arm_ignore_isr(void)
 }
 
 #define isr(name) \
-	void __attribute__ ((weak)) arm_ ## name ## _isr(void); \
-	_Pragma(STRINGIFY(weak arm_ ## name ## _isr = arm_ignore_isr))
+	void  arm_ ## name ## _isr(void) __attribute__ ((weak, alias("arm_ignore_isr")));
 
 #define isr_halt(name) \
-	void __attribute__ ((weak)) arm_ ## name ## _isr(void); \
-	_Pragma(STRINGIFY(weak arm_ ## name ## _isr = arm_halt_isr))
+	void  arm_ ## name ## _isr(void) __attribute__ ((weak, alias("arm_halt_isr")));
 
 isr(nmi);
 isr_halt(hardfault);
@@ -73,11 +71,11 @@ isr(systick);
 void _start(void);
 extern uint8_t __stack[];
 
-#define i(addr,name)	[(addr)/4] = arm_ ## name ## _isr
-/*
+#define i(addr,name)	[(addr)/4] = (void(*)(void)) arm_ ## name ## _isr
+
 __section(".data.init.enter")
-const void *__weak_interrupt_vector[] __attribute((aligned(128))) = {
-	[0] = __stack,
+void (* const __weak_interrupt_vector[])(void) __attribute((aligned(128))) = {
+	[0] = (void(*)(void))__stack,
 	[1] = _start,
 	i(0x08, nmi),
 	i(0x0c, hardfault),
@@ -87,4 +85,3 @@ const void *__weak_interrupt_vector[] __attribute((aligned(128))) = {
 	i(0x3c, systick),
 };
 __weak_reference(__weak_interrupt_vector, __interrupt_vector);
-*/

--- a/newlib/libc/picolib/meson.build
+++ b/newlib/libc/picolib/meson.build
@@ -50,14 +50,14 @@ srcs_picolib = [
   'picosbrk.c',
 ]
 
-if srcs_machine.has_key(host_cpu)
-  srcs_picolib += srcs_machine[host_cpu]
+if srcs_machine.has_key(host_cpu_family)
+  srcs_picolib += srcs_machine[host_cpu_family]
 endif
 
 if thread_local_storage
   srcs_picolib += srcs_tls
-  if srcs_machine_tls.has_key(host_cpu)
-    srcs_picolib += srcs_machine_tls[host_cpu]
+  if srcs_machine_tls.has_key(host_cpu_family)
+    srcs_picolib += srcs_machine_tls[host_cpu_family]
   endif
 endif
 

--- a/newlib/libm/meson.build
+++ b/newlib/libm/meson.build
@@ -52,15 +52,15 @@ libnames = libdirs
 
 need_generic_fenv = true
 
-if libm_machine_dirs.has_key(host_cpu)
-  libm_machine_dir = join_paths('machine', libm_machine_dirs[host_cpu])
+if libm_machine_dirs.has_key(host_cpu_family)
+  libm_machine_dir = join_paths('machine', libm_machine_dirs[host_cpu_family])
   libdirs = [libm_machine_dir] + libdirs
   libnames = ['machine'] + libnames
   if run_command('test', '-f', join_paths(libm_machine_dir, 'fegetenv.c')).returncode() == 0
     need_generic_fenv = false
   endif
 else
-  warning('No libm machine directory for cpu ' + host_cpu)
+  warning('No libm machine directory for CPU family ' + host_cpu_family)
 endif
 
 if need_generic_fenv

--- a/picocrt/meson.build
+++ b/picocrt/meson.build
@@ -38,8 +38,8 @@ src_picocrt_machine = {
 			'arm' : 'arm/crt0.c'
 		      }
 
-if src_picocrt_machine.has_key(host_cpu)
-  srcs_picocrt = join_paths('machine', src_picocrt_machine[host_cpu])
+if src_picocrt_machine.has_key(host_cpu_family)
+  srcs_picocrt = join_paths('machine', src_picocrt_machine[host_cpu_family])
 else
   srcs_picocrt = 'shared/crt0.c'
 endif

--- a/semihost/meson.build
+++ b/semihost/meson.build
@@ -38,7 +38,7 @@ src_semihost_machine = {
 			'arm' : 'arm/semihost-arm.c'
 		      }
 
-if src_semihost_machine.has_key(host_cpu)
+if src_semihost_machine.has_key(host_cpu_family)
   srcs_semihost = [
     'close.c',
     'exit.c',
@@ -60,7 +60,7 @@ if src_semihost_machine.has_key(host_cpu)
     'sys_putc.c',
     'sys_read.c',
     'sys_remove.c',
-    join_paths('machine', src_semihost_machine[host_cpu])
+    join_paths('machine', src_semihost_machine[host_cpu_family])
   ]
 
   install_headers(


### PR DESCRIPTION
(do not merge!)

Hi! I just found what for some reason `__aeabi_memcpy` & Co functions is not builds for ARM because `meson.build` uses `cpu` (contains "cortex-m3") instead of `cpu_family` variable (contains "arm").

I changed this and faced what some code what was previously unused (?) now fails at compilation with error:
```
newlib/libc/picolib/machine/arm/interrupt.c:83:15: error: initializing 'const void *'
with an expression of incompatible type '<overloaded function type>'
```

I commented out `__weak_interrupt_vector` but actually have not idea how to fix this by the right way. 