### PR TITLE
Fix unbalanced diagnostics pragma

### DIFF
--- a/newlib/libm/common/math_config.h
+++ b/newlib/libm/common/math_config.h
@@ -208,6 +208,7 @@ opt_barrier_double (double x)
   volatile double y = x;
   return y;
 }
+#pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-variable"
 static inline void
 force_eval_float (float x)


### PR DESCRIPTION
Clang 9 is complaining about this and the code appears to be wrong.

```
In file included from /home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/newlib/libm/common/s_expm1.c:145:
/home/ayke/src/github.com/tinygo-org/tinygo/lib/picolibc/newlib/libm/common/math_config.h:222:24: error: pragma diagnostic pop could not pop, no matching push [-Werror,-Wunknown-pragmas]
#pragma GCC diagnostic pop
                       ^
1 error generated.
```

Note that I'm using a custom build system (to avoid external dependencies, among other reasons) so perhaps there is something different in my setup that causes this error to appear.

---

Sidenote: thanks a lot for your work on picolibc! It's being used now as a C library in TinyGo for most bare metal targets: https://github.com/tinygo-org/tinygo/pull/871