### PR TITLE
Correct the typo in the DESCRIPTION

### DIFF
--- a/newlib/libc/string/strncpy.c
+++ b/newlib/libc/string/strncpy.c
@@ -27,7 +27,7 @@ SYNOPSIS
                       size_t <[length]>);
 
 DESCRIPTION
-	<<strncpy>> copies not more than <[length]> characters from the
+	<<strncpy>> copies not more than <[length]> characters from
 	the string pointed to by <[src]> (including the terminating
 	null character) to the array pointed to by <[dst]>.  If the
 	string pointed to by <[src]> is shorter than <[length]>


### PR DESCRIPTION
This PR just correct the typo in DESCRIPTION of strncpy function.
Old: copies not more than <[length]> characters from **the the** string
New: copies not more than <[length]> characters from **the** string