### PR TITLE
__attribute__((used)) for newlib/libc/machine/arm/aeabi_*.c

### DIFF
--- a/newlib/libc/machine/arm/aeabi_memclr.c
+++ b/newlib/libc/machine/arm/aeabi_memclr.c
@@ -38,7 +38,7 @@ void __aeabi_memclr8 (void *dest, size_t n)
 	_ATTRIBUTE ((alias ("__aeabi_memclr")));
 
 /* Support the routine __aeabi_memclr.  */
-void __aeabi_memclr (void *dest, size_t n)
+void __attribute__((used)) __aeabi_memclr (void *dest, size_t n)
 {
   extern void __aeabi_memset (void *dest, size_t n, int c);
   __aeabi_memset (dest, n, 0);

--- a/newlib/libc/machine/arm/aeabi_memset.c
+++ b/newlib/libc/machine/arm/aeabi_memset.c
@@ -55,7 +55,7 @@ void __aeabi_memset8 (void *dest, size_t n, int c)
 
 /* Support the routine __aeabi_memset.  Can't alias to memset
    because it's not defined in the same translation unit.  */
-void __aeabi_memset (void *dest, size_t n, int c)
+void __attribute__((used)) __aeabi_memset (void *dest, size_t n, int c)
 {
   /*Note that relative to ANSI memset, __aeabi_memset hase the order
     of its second and third arguments reversed.  */


### PR DESCRIPTION
Strange thing: if -flto enabled for some reason linker drops out these symbols. I checked - they are defined in .a files, but when linking for some reason they are not taken into result if this attribute isn't enabled.

I can’t understand what is reason of that behaviour. Problem does not occur if you do not use -flto.

clang-11 compiler is used
