### PR TITLE
Changes __assert args order (as in glibc)

### DIFF
--- a/newlib/libc/include/assert.h
+++ b/newlib/libc/include/assert.h
@@ -69,7 +69,7 @@ extern "C" {
 # endif /* !__ASSERT_FUNC */
 #endif /* !NDEBUG */
 
-void __assert (const char *, int, const char *)
+void __assert (const char *, const char *, int)
 	    _ATTRIBUTE ((__noreturn__));
 void __assert_func (const char *, int, const char *, const char *)
 	    _ATTRIBUTE ((__noreturn__));

--- a/newlib/libc/stdlib/assert.c
+++ b/newlib/libc/stdlib/assert.c
@@ -69,9 +69,9 @@ __assert_func (const char *file,
 #endif /* HAVE_ASSERT_FUNC */
 
 void
-__assert (const char *file,
-	int line,
-	const char *failedexpr)
+__assert (const char *failedexpr,
+	const char *file,
+	int line)
 {
    __assert_func (file, line, NULL, failedexpr);
   /* NOTREACHED */


### PR DESCRIPTION
Is this acceptable?
I just figured out why my project shows assertion erros with garbage while moved from Linux to bare metal.

Is there any standard for `__assert` args?