### PR TITLE
meson: obey cross-file c_args without multilib

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -287,7 +287,7 @@ if enable_multilib
   endif
 else
   targets = ['']
-  target_ = ['.', []]
+  target_ = ['.', meson.get_cross_property('c_args')]
 endif
 
 conf_data = configuration_data()

--- a/meson.build
+++ b/meson.build
@@ -287,7 +287,7 @@ if enable_multilib
   endif
 else
   targets = ['']
-  target_ = ['.', meson.get_cross_property('c_args')]
+  target_ = ['.', meson.get_cross_property('c_args', [])]
 endif
 
 conf_data = configuration_data()


### PR DESCRIPTION
When cross compiling without multilib we still want the c_args to apply
to all compilation commands.

Without this we get an error building for rv32 without multilib.

Cross-compiling without multilib is useful when embedding the picolibc sources inside an embedded project, because we save compilation time by only building for the actual target platform instead of all possible multilibs.