### PR TITLE
Suppress 'warning: unused variable" when NDEBUG on some cases

### DIFF
--- a/newlib/libc/include/assert.h
+++ b/newlib/libc/include/assert.h
@@ -44,7 +44,7 @@ extern "C" {
 #undef assert
 
 #ifdef NDEBUG           /* required by ANSI standard */
-# define assert(__e) ((void)0)
+# define assert(__e) do { (void)sizeof(__e); } while(0)
 #else
 # define assert(__e) ((__e) ? (void)0 : __assert_func (__FILE__, __LINE__, \
 						       __ASSERT_FUNC, #__e))


### PR DESCRIPTION
For cases like that, when NDEBUG is defined

```
int res = func();
assert(res > 0);
```

ref http://cnicholson.net/2009/02/stupid-c-tricks-adventures-in-assert/